### PR TITLE
Configure GitHub Pages deployment via Actions

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,15 +1,15 @@
 name: deploy
-
 on:
   push:
     branches:
       - main
-
 permissions:
   contents: read
   pages: write
   id-token: write
-
+concurrency:
+  group: pages
+  cancel-in-progress: true
 defaults:
   run:
     working-directory: cannaclicker
@@ -23,15 +23,20 @@ jobs:
         with:
           node-version: 20
           cache: npm
-          cache-dependency-path: cannaclicker/package-lock.json
       - run: npm ci
       - run: npm run build
+      - run: |
+          rm -rf ../dist
+          mv dist ../dist
       - uses: actions/upload-pages-artifact@v3
         with:
-          path: cannaclicker/dist
-
+          path: dist
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/deploy-pages@v4
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/cannaclicker/vite.config.ts
+++ b/cannaclicker/vite.config.ts
@@ -1,18 +1,13 @@
-import { defineConfig, loadEnv } from 'vite';
+import { defineConfig } from 'vite';
 import compression from 'vite-plugin-compression';
 
-export default defineConfig(({ mode }) => {
-  const env = loadEnv(mode, process.cwd(), '');
-  const base = env.VITE_BASE_PATH && env.VITE_BASE_PATH.length > 0 ? env.VITE_BASE_PATH : '/';
-
-  return {
-    base,
-    plugins: [
-      compression({ algorithm: 'brotliCompress', ext: '.br' }),
-      compression({ algorithm: 'gzip', ext: '.gz' }),
-    ],
-    build: {
-      sourcemap: mode !== 'production' ? true : false,
-    },
-  };
-});
+export default defineConfig(({ mode }) => ({
+  base: '/',
+  plugins: [
+    compression({ algorithm: 'brotliCompress', ext: '.br' }),
+    compression({ algorithm: 'gzip', ext: '.gz' }),
+  ],
+  build: {
+    sourcemap: mode !== 'production',
+  },
+}));


### PR DESCRIPTION
## Summary
- configure the GitHub Pages workflow to build with Node 20, run the Cannaclicker build, and upload the generated dist folder
- update the Vite configuration to use the root path so builds work for the user site

## Testing
- npm run build *(fails: project index.html references pre-built hashed assets committed to the repo)*

------
https://chatgpt.com/codex/tasks/task_e_68cc504f4358832d87bb7dc11f6c51ef