### PR TITLE
Fix asset base URL resolution

### DIFF
--- a/cannaclicker/src/app/paths.ts
+++ b/cannaclicker/src/app/paths.ts
@@ -1,5 +1,40 @@
-﻿export const withBase = (path: string): string => {
-  const base = import.meta.env.BASE_URL.replace(/\/?$/, "/");
-  const normalized = path.replace(/^\.?\/+/, "");
-  return `${base}${normalized}`;
+const stripLeading = (path: string): string => path.replace(/^\.?\/+/, "");
+
+const ensureDirectoryHref = (raw: string): string => {
+  const url = new URL(raw);
+  url.search = "";
+  url.hash = "";
+
+  if (/\.[^/]+$/.test(url.pathname)) {
+    url.pathname = url.pathname.replace(/[^/]*$/, "");
+  } else if (!url.pathname.endsWith("/")) {
+    url.pathname = `${url.pathname}/`;
+  }
+
+  return url.href;
+};
+
+const resolveBaseUrl = (): string | null => {
+  if (typeof document !== "undefined" && document.baseURI) {
+    return ensureDirectoryHref(document.baseURI);
+  }
+
+  if (typeof window !== "undefined" && window.location?.href) {
+    return ensureDirectoryHref(window.location.href);
+  }
+
+  return null;
+};
+
+export const withBase = (path: string): string => {
+  const normalized = stripLeading(path);
+  const runtimeBase = resolveBaseUrl();
+
+  if (runtimeBase) {
+    const baseUrl = new URL(import.meta.env.BASE_URL, runtimeBase);
+    return new URL(normalized, baseUrl).pathname;
+  }
+
+  const fallback = import.meta.env.BASE_URL.replace(/\/?$/, "/");
+  return `${fallback}${normalized}`;
 };


### PR DESCRIPTION
## Summary
- normalize runtime base URLs before composing asset paths so images and backgrounds load under GitHub Pages

## Testing
- npm run build
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd0c19a748832d99144f7cc4d43e06