### PR TITLE
Fix asset base URL resolution

### DIFF
--- a/cannaclicker/public/img/logo-leaf.svg
+++ b/cannaclicker/public/img/logo-leaf.svg
@@ -1,7 +1,7 @@
-<![CDATA[<svg width="512" height="512" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+<svg width="512" height="512" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
   <path d="M256 40C150 40 64 126 64 232C64 338 150 424 256 424C362 424 448 338 448 232C448 126 362 40 256 40Z" stroke="#2D7D32" stroke-width="8" fill="none"/>
   <path d="M256 100L256 400" stroke="#2D7D32" stroke-width="8" stroke-linecap="round"/>
   <path d="M180 150L256 200L332 150" stroke="#2D7D32" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"/>
   <path d="M180 220L256 270L332 220" stroke="#2D7D32" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"/>
   <path d="M180 290L256 340L332 290" stroke="#2D7D32" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"/>
-</svg>]]>
+</svg>

--- a/cannaclicker/public/img/logo-wordmark.svg
+++ b/cannaclicker/public/img/logo-wordmark.svg
@@ -1,5 +1,4 @@
-<![CDATA[<svg width="1200" height="512" viewBox="0 0 1200 512" xmlns="http://www.w3.org/2000/svg">
-  <!-- Cannabis Leaf -->
+<svg width="1200" height="512" viewBox="0 0 1200 512" xmlns="http://www.w3.org/2000/svg">
   <g transform="translate(100, 56)">
     <path d="M128 0C60 0 0 60 0 128C0 196 60 256 128 256C196 256 256 196 256 128C256 60 196 0 128 0Z" stroke="#2D7D32" stroke-width="4" fill="none"/>
     <path d="M128 30L128 26" stroke="#2D7D32" stroke-width="4" stroke-linecap="round"/>
@@ -7,8 +6,6 @@
     <path d="M90 110L128 135L166 110" stroke="#2D7D32" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
     <path d="M90 145L128 170L166 145" stroke="#2D7D32" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
   </g>
-  
-  <!-- Wordmark Text -->
   <text x="300" y="180" font-family="Arial, sans-serif" font-size="100" font-weight="bold" fill="#2D7D32">CannaClicker</text>
   <text x="300" y="280" font-family="Arial, sans-serif" font-size="40" fill="#2D7D32">Grow Your Fortune</text>
-</svg>]]>
+</svg>

--- a/cannaclicker/src/app/paths.ts
+++ b/cannaclicker/src/app/paths.ts
@@ -1,5 +1,40 @@
-﻿export const withBase = (path: string): string => {
-  const base = import.meta.env.BASE_URL.replace(/\/?$/, "/");
-  const normalized = path.replace(/^\.?\/+/, "");
-  return `${base}${normalized}`;
+const stripLeading = (path: string): string => path.replace(/^\.?\/+/, "");
+
+const ensureDirectoryHref = (raw: string): string => {
+  const url = new URL(raw);
+  url.search = "";
+  url.hash = "";
+
+  if (/\.[^/]+$/.test(url.pathname)) {
+    url.pathname = url.pathname.replace(/[^/]*$/, "");
+  } else if (!url.pathname.endsWith("/")) {
+    url.pathname = `${url.pathname}/`;
+  }
+
+  return url.href;
+};
+
+const resolveBaseUrl = (): string | null => {
+  if (typeof document !== "undefined" && document.baseURI) {
+    return ensureDirectoryHref(document.baseURI);
+  }
+
+  if (typeof window !== "undefined" && window.location?.href) {
+    return ensureDirectoryHref(window.location.href);
+  }
+
+  return null;
+};
+
+export const withBase = (path: string): string => {
+  const normalized = stripLeading(path);
+  const runtimeBase = resolveBaseUrl();
+
+  if (runtimeBase) {
+    const baseUrl = new URL(import.meta.env.BASE_URL, runtimeBase);
+    return new URL(normalized, baseUrl).pathname;
+  }
+
+  const fallback = import.meta.env.BASE_URL.replace(/\/?$/, "/");
+  return `${fallback}${normalized}`;
 };


### PR DESCRIPTION
## Summary
- normalize runtime base URLs before composing asset paths so images and backgrounds load under GitHub Pages
- replace the header logo SVGs with valid markup so they render correctly

## Testing
- npm run build
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd0c19a748832d99144f7cc4d43e06