### PR TITLE
Fix plant stage icon transparency

### DIFF
--- a/cannaclicker/src/app/ui.ts
+++ b/cannaclicker/src/app/ui.ts
@@ -33,7 +33,7 @@ interface UIRefs {
   total: HTMLElement;
   clickButton: HTMLButtonElement;
   clickLabel: HTMLSpanElement;
-  clickIcon: HTMLImageElement;
+  clickIcon: HTMLDivElement;
   controls: {
     mute: ControlButtonRefs;
     export: ControlButtonRefs;
@@ -145,10 +145,13 @@ function buildUI(state: GameState): UIRefs {
   clickButton.className = "click-button w-full";
   clickButton.type = "button";
 
-  const clickIcon = new Image();
-  clickIcon.src = withBase("plant-stages/plant-stage-01.png");
-  clickIcon.alt = "";
+  const clickIcon = document.createElement("div");
   clickIcon.className = "click-icon";
+  clickIcon.setAttribute("aria-hidden", "true");
+  clickIcon.style.setProperty(
+    "background-image",
+    `url("${withBase("plant-stages/plant-stage-01.png")}")`,
+  );
   clickIcon.dataset.stage = "1";
 
   const clickLabel = document.createElement("span");
@@ -379,7 +382,10 @@ function updatePlantStage(state: GameState): void {
 
   refs.clickIcon.dataset.stage = nextStage.toString();
   const assetPath = `plant-stages/plant-stage-${nextStage.toString().padStart(2, "0")}.png`;
-  refs.clickIcon.src = withBase(assetPath);
+  refs.clickIcon.style.setProperty(
+    "background-image",
+    `url("${withBase(assetPath)}")`,
+  );
 }
 
 function updateStats(state: GameState): void {

--- a/cannaclicker/src/styles/index.css
+++ b/cannaclicker/src/styles/index.css
@@ -85,6 +85,10 @@ button {
 
 .click-icon {
   @apply h-28 w-28 transition-transform;
+  background-color: transparent;
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: contain;
 }
 
 .click-button:active .click-icon {


### PR DESCRIPTION
## Summary
- render the harvest button icon as a div with a background image so the PNG transparency is preserved
- update the click icon styling to center and contain the background artwork while keeping its scale animation

## Testing
- npm run build
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd15cca490832dbc11ee26ae1affa2