### PR TITLE
Refine header layout and controls

### DIFF
--- a/cannaclicker/src/app/ui.ts
+++ b/cannaclicker/src/app/ui.ts
@@ -216,43 +216,41 @@ function mountHeader(root: HTMLElement, controls: HTMLButtonElement[]): void {
 
   const brand = document.createElement("div");
   brand.className =
-    "flex items-center gap-5 rounded-2xl bg-neutral-900/60 px-4 py-3 shadow-[0_18px_32px_rgba(16,185,129,0.25)] ring-1 ring-emerald-400/25 backdrop-blur";
+    "flex items-center gap-6 rounded-2xl bg-neutral-900/60 px-5 py-4 shadow-[0_18px_32px_rgba(16,185,129,0.25)] ring-1 ring-emerald-400/25 backdrop-blur";
 
   const leafWrap = document.createElement("span");
   leafWrap.className =
-    "relative grid h-14 w-14 place-items-center rounded-2xl bg-gradient-to-br from-emerald-400/30 via-emerald-500/20 to-emerald-700/30 shadow-[0_0_32px_rgba(16,185,129,0.35)] ring-1 ring-emerald-400/30";
+    "relative grid h-16 w-16 place-items-center rounded-2xl bg-gradient-to-br from-emerald-400/30 via-emerald-500/20 to-emerald-700/30 shadow-[0_0_32px_rgba(16,185,129,0.35)] ring-1 ring-emerald-400/30";
 
   const leaf = new Image();
   leaf.src = withBase("img/logo-leaf.svg");
   leaf.alt = "";
   leaf.decoding = "async";
-  leaf.className = "h-9 w-9 drop-shadow-[0_10px_22px_rgba(16,185,129,0.55)]";
+  leaf.className = "h-11 w-11 drop-shadow-[0_10px_22px_rgba(16,185,129,0.55)]";
 
   leafWrap.appendChild(leaf);
 
   const brandText = document.createElement("div");
-  brandText.className = "flex flex-col";
+  brandText.className = "flex flex-col justify-center";
 
   const wordmark = new Image();
   wordmark.src = withBase("img/logo-wordmark.svg");
   wordmark.alt = "CannaClicker";
   wordmark.decoding = "async";
   wordmark.className =
-    "h-10 w-auto drop-shadow-[0_14px_28px_rgba(34,197,94,0.45)] saturate-150";
+    "h-12 w-auto drop-shadow-[0_18px_32px_rgba(34,197,94,0.45)] saturate-150";
 
-  const brandSubtitle = document.createElement("span");
-  brandSubtitle.textContent = "Galaktischer Grow-Simulator";
-  brandSubtitle.className =
-    "mt-1 text-[0.7rem] font-semibold uppercase tracking-[0.5em] text-emerald-200/80";
-
-  brandText.append(wordmark, brandSubtitle);
+  brandText.append(wordmark);
 
   brand.append(leafWrap, brandText);
 
   const actionWrap = document.createElement("div");
   actionWrap.className =
-    "flex flex-wrap items-center gap-3 rounded-2xl bg-neutral-900/50 px-3 py-2.5 shadow-[0_20px_38px_rgba(15,23,42,0.45)] ring-1 ring-white/10 backdrop-blur";
-  controls.forEach((control) => actionWrap.append(control));
+    "flex flex-nowrap items-center gap-2 overflow-x-auto rounded-2xl bg-neutral-900/50 px-3 py-2 shadow-[0_20px_38px_rgba(15,23,42,0.45)] ring-1 ring-white/10 backdrop-blur sm:px-4";
+  controls.forEach((control) => {
+    control.classList.add("shrink-0");
+    actionWrap.append(control);
+  });
 
   header.append(brand, actionWrap);
   root.prepend(header);
@@ -283,7 +281,7 @@ function setupInteractions(refs: UIRefs, state: GameState): void {
   });
 
   refs.controls.import.button.addEventListener("click", () => {
-    const payload = window.prompt("Bitte Base64-Spielstand einfügen:");
+    const payload = window.prompt("Bitte Base64-Spielstand einfÃ¼gen:");
     if (!payload) {
       return;
     }
@@ -302,7 +300,7 @@ function setupInteractions(refs: UIRefs, state: GameState): void {
   });
 
   refs.controls.reset.button.addEventListener("click", () => {
-    const confirmReset = window.confirm("Spielstand wirklich löschen?");
+    const confirmReset = window.confirm("Spielstand wirklich lÃ¶schen?");
     if (!confirmReset) {
       return;
     }
@@ -592,7 +590,7 @@ function createActionButton(iconPath: string): ControlButtonRefs {
   const button = document.createElement("button");
   button.type = "button";
   button.className =
-    "inline-flex items-center gap-3 rounded-xl border border-white/15 bg-neutral-900/60 px-4 py-2.5 text-sm font-semibold text-neutral-100 shadow-[0_6px_20px_rgba(15,23,42,0.45)] transition hover:border-leaf-400/70 hover:text-leaf-100 focus-visible:ring-2 focus-visible:ring-leaf-300/70";
+    "inline-flex items-center gap-2 rounded-lg border border-white/15 bg-neutral-900/60 px-3 py-1.5 text-xs font-semibold text-neutral-100 shadow-[0_6px_16px_rgba(15,23,42,0.4)] transition hover:border-leaf-400/70 hover:text-leaf-100 focus-visible:ring-2 focus-visible:ring-leaf-300/70";
 
   const icon = new Image();
   icon.src = iconPath;
@@ -604,7 +602,7 @@ function createActionButton(iconPath: string): ControlButtonRefs {
   icon.classList.add("control-icon-img");
 
   const label = document.createElement("span");
-  label.className = "whitespace-nowrap uppercase tracking-[0.25em]";
+  label.className = "whitespace-nowrap text-[0.65rem] uppercase tracking-[0.35em]";
 
   button.append(iconWrap, label);
 

--- a/cannaclicker/src/styles/index.css
+++ b/cannaclicker/src/styles/index.css
@@ -51,14 +51,14 @@ button {
 }
 
 .control-icon-badge {
-  @apply bg-emerald-400/15 border-emerald-300/30 p-2.5;
-  box-shadow: 0 12px 24px rgba(16, 185, 129, 0.35);
+  @apply bg-emerald-400/15 border-emerald-300/30 p-1.5;
+  box-shadow: 0 8px 18px rgba(16, 185, 129, 0.28);
 }
 
 .control-icon-img {
-  width: 1.5rem;
-  height: 1.5rem;
-  filter: drop-shadow(0 10px 18px rgba(16, 185, 129, 0.45));
+  width: 1.25rem;
+  height: 1.25rem;
+  filter: drop-shadow(0 8px 16px rgba(16, 185, 129, 0.4));
 }
 
 .card {


### PR DESCRIPTION
## Summary
- enlarge the CannaClicker branding and remove the subtitle text from the header
- tighten the header control layout so the buttons sit on a single row with smaller styling
- shrink control icon styling to match the lighter button proportions

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd1d97de64832d92909c8e8e69a5e2