### PR TITLE
Use provided audio files for click and purchase sounds

### DIFF
--- a/cannaclicker/src/app/audio.ts
+++ b/cannaclicker/src/app/audio.ts
@@ -14,12 +14,12 @@ export function createAudioManager(initialMuted: boolean): AudioManager {
   Howler.mute(muted);
 
   const click = new Howl({
-    src: [createToneDataUrl(420, 130)],
+    src: ['/sounds/click.wav'],
     volume: 0.45,
   });
 
   const purchase = new Howl({
-    src: [createToneDataUrl(540, 180)],
+    src: ['/sounds/purchase.wav'],
     volume: 0.5,
   });
 
@@ -51,53 +51,4 @@ export function createAudioManager(initialMuted: boolean): AudioManager {
   };
 
   return manager;
-}
-
-function createToneDataUrl(frequency: number, durationMs: number): string {
-  const sampleRate = 44100;
-  const sampleCount = Math.floor((durationMs / 1000) * sampleRate);
-  const bytesPerSample = 2;
-  const blockAlign = bytesPerSample;
-  const byteRate = sampleRate * blockAlign;
-  const buffer = new ArrayBuffer(44 + sampleCount * bytesPerSample);
-  const view = new DataView(buffer);
-
-  writeString(view, 0, 'RIFF');
-  view.setUint32(4, 36 + sampleCount * bytesPerSample, true);
-  writeString(view, 8, 'WAVE');
-  writeString(view, 12, 'fmt ');
-  view.setUint32(16, 16, true);
-  view.setUint16(20, 1, true);
-  view.setUint16(22, 1, true);
-  view.setUint32(24, sampleRate, true);
-  view.setUint32(28, byteRate, true);
-  view.setUint16(32, blockAlign, true);
-  view.setUint16(34, 16, true);
-  writeString(view, 36, 'data');
-  view.setUint32(40, sampleCount * bytesPerSample, true);
-
-  for (let i = 0; i < sampleCount; i += 1) {
-    const t = i / sampleRate;
-    const envelope = Math.exp(-4 * t);
-    const sample = Math.sin(2 * Math.PI * frequency * t) * envelope * 0.75;
-    view.setInt16(44 + i * bytesPerSample, Math.max(-1, Math.min(1, sample)) * 32767, true);
-  }
-
-  return `data:audio/wav;base64,${encodeBase64(new Uint8Array(buffer))}`;
-}
-
-function writeString(view: DataView, offset: number, text: string): void {
-  for (let i = 0; i < text.length; i += 1) {
-    view.setUint8(offset + i, text.charCodeAt(i));
-  }
-}
-
-function encodeBase64(bytes: Uint8Array): string {
-  let binary = '';
-  const chunkSize = 0x8000;
-  for (let i = 0; i < bytes.length; i += chunkSize) {
-    const chunk = bytes.subarray(i, i + chunkSize);
-    binary += String.fromCharCode(...chunk);
-  }
-  return btoa(binary);
 }


### PR DESCRIPTION
## Summary
- swap procedural tone generation for the new click and purchase audio files in the public sounds directory
- keep the audio manager interface unchanged while using the externally supplied assets

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd2e820fb8832d8356f6cf26f73904