### PR TITLE
Enhance stats overview readability

### DIFF
--- a/cannaclicker/src/app/ui.ts
+++ b/cannaclicker/src/app/ui.ts
@@ -234,7 +234,8 @@ function buildUI(state: GameState): UIRefs {
   }
 
   root.innerHTML = "";
-  root.className = "mx-auto flex w-full max-w-6xl flex-col gap-4 p-4";
+  root.className =
+    "mx-auto flex w-full max-w-[92rem] flex-col gap-6 px-4 pb-8 pt-4 sm:px-6 lg:px-10";
 
   const heroImageSet = `image-set(url("${withBase("img/bg-hero-1920.png")}") type("image/png") 1x, url("${withBase("img/bg-hero-2560.png")}") type("image/png") 2x)`;
   document.documentElement.style.setProperty("--hero-image", heroImageSet);
@@ -258,7 +259,8 @@ function buildUI(state: GameState): UIRefs {
   ]);
 
   const layout = document.createElement("div");
-  layout.className = "grid gap-4 lg:grid-cols-[1fr_1fr] xl:gap-6";
+  layout.className =
+    "grid gap-4 lg:grid-cols-[minmax(0,1.05fr)_minmax(0,0.95fr)] xl:gap-6 2xl:gap-8";
   root.appendChild(layout);
 
   const primaryColumn = document.createElement("div");
@@ -270,28 +272,28 @@ function buildUI(state: GameState): UIRefs {
   layout.append(primaryColumn, secondaryColumn);
 
   const headerCard = document.createElement("section");
-  headerCard.className = "card fade-in space-y-4";
+  headerCard.className = "card fade-in space-y-3";
 
   const title = document.createElement("h1");
   title.className = "text-4xl md:text-5xl font-extrabold tracking-tight text-leaf-200 drop-shadow-[0_14px_28px_rgba(16,185,129,0.35)]";
   title.textContent = "CannaBies";
   headerCard.appendChild(title);
 
-  const statsGrid = document.createElement("div");
-  statsGrid.className = "stats-grid text-neutral-300";
-  headerCard.appendChild(statsGrid);
+  const statsList = document.createElement("dl");
+  statsList.className = "stats-list";
+  headerCard.appendChild(statsList);
 
   const statsLabels = new Map<string, HTMLElement>();
   const statsMeta = new Map<string, HTMLElement>();
 
-  const budsStat = createStatBlock("stats.buds", statsGrid, statsLabels, statsMeta);
-  const bpsStat = createStatBlock("stats.bps", statsGrid, statsLabels, statsMeta);
-  const bpcStat = createStatBlock("stats.bpc", statsGrid, statsLabels, statsMeta);
-  const totalStat = createStatBlock("stats.total", statsGrid, statsLabels, statsMeta);
-  const seedsStat = createStatBlock("stats.seeds", statsGrid, statsLabels, statsMeta);
+  const budsStat = createStatBlock("stats.buds", statsList, statsLabels, statsMeta);
+  const bpsStat = createStatBlock("stats.bps", statsList, statsLabels, statsMeta);
+  const bpcStat = createStatBlock("stats.bpc", statsList, statsLabels, statsMeta);
+  const totalStat = createStatBlock("stats.total", statsList, statsLabels, statsMeta);
+  const seedsStat = createStatBlock("stats.seeds", statsList, statsLabels, statsMeta);
   const prestigeStat = createStatBlock(
     "stats.prestigeMult",
-    statsGrid,
+    statsList,
     statsLabels,
     statsMeta,
   );
@@ -421,7 +423,7 @@ function buildUI(state: GameState): UIRefs {
 function mountHeader(root: HTMLElement, controls: HTMLButtonElement[]): void {
   const header = document.createElement("header");
   header.className =
-    "mx-auto flex w-full max-w-6xl flex-col items-start gap-4 rounded-3xl border border-white/10 bg-neutral-900/80 px-4 py-4 shadow-[0_24px_60px_rgba(10,12,21,0.55)] backdrop-blur-xl sm:flex-row sm:items-center sm:justify-between sm:gap-6 sm:px-6";
+    "flex w-full flex-col items-start gap-4 rounded-3xl border border-white/10 bg-neutral-900/80 px-4 py-4 shadow-[0_24px_60px_rgba(10,12,21,0.55)] backdrop-blur-xl sm:flex-row sm:items-center sm:justify-between sm:gap-6 sm:px-6 lg:px-8";
 
   const brand = document.createElement("div");
   brand.className =
@@ -1394,37 +1396,28 @@ function createStatBlock(
   labelRegistry: Map<string, HTMLElement>,
   metaRegistry: Map<string, HTMLElement>,
 ): HTMLElement {
-  const group = document.createElement("article");
-  group.className = "stat-card";
-  group.dataset.variant = key;
+  const item = document.createElement("div");
+  item.className = "stat-line";
+  item.dataset.variant = key;
 
-  const header = document.createElement("div");
-  header.className = "stat-card__header";
-
-  const indicator = document.createElement("span");
-  indicator.className = "stat-card__indicator";
-  indicator.setAttribute("aria-hidden", "true");
-
-  const label = document.createElement("span");
-  label.className = "stat-card__label";
+  const label = document.createElement("dt");
+  label.className = "stat-line__label";
   labelRegistry.set(key, label);
 
-  header.append(indicator, label);
-
-  const valueWrapper = document.createElement("div");
-  valueWrapper.className = "stat-card__value";
+  const valueWrapper = document.createElement("dd");
+  valueWrapper.className = "stat-line__value";
 
   const value = document.createElement("span");
-  value.className = "stat-card__number";
+  value.className = "stat-line__number";
 
   const meta = document.createElement("span");
-  meta.className = "stat-card__meta";
+  meta.className = "stat-line__meta";
   metaRegistry.set(key, meta);
 
   valueWrapper.append(value, meta);
 
-  group.append(header, valueWrapper);
-  wrapper.appendChild(group);
+  item.append(label, valueWrapper);
+  wrapper.appendChild(item);
 
   return value;
 }

--- a/cannaclicker/src/styles/index.css
+++ b/cannaclicker/src/styles/index.css
@@ -120,190 +120,110 @@ button {
   bottom: clamp(1.75rem, 5vw, 2.75rem);
   letter-spacing: 0.45em;
 }
-.stats-grid {
+.stats-list {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: clamp(1rem, 2.4vw, 1.75rem);
-  align-items: stretch;
-  grid-auto-flow: dense;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: clamp(0.6rem, 1.6vw, 1rem);
 }
 
-@media (min-width: 768px) {
-  .stats-grid {
-    grid-template-columns: repeat(6, minmax(0, 1fr));
-  }
-}
-
-@media (min-width: 1280px) {
-  .stats-grid {
-    grid-template-columns: repeat(12, minmax(0, 1fr));
-  }
-}
-
-.stat-card {
+.stat-line {
   position: relative;
-  display: flex;
-  flex-direction: column;
-  gap: clamp(0.9rem, 1.8vw, 1.4rem);
-  padding: clamp(1.15rem, 2.6vw, 2rem);
-  border-radius: 1.6rem;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  background: linear-gradient(158deg, rgba(15, 23, 42, 0.9), rgba(11, 18, 32, 0.78));
-  box-shadow: 0 26px 52px rgba(10, 12, 21, 0.5);
-  backdrop-filter: blur(18px);
-  min-height: clamp(7.25rem, 11vw, 9.5rem);
-  overflow: hidden;
-  transition: transform 160ms ease, border-color 160ms ease, box-shadow 160ms ease;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: baseline;
+  column-gap: clamp(0.75rem, 2vw, 1.25rem);
+  row-gap: 0.35rem;
+  padding: clamp(0.85rem, 2.2vw, 1.15rem) clamp(1rem, 2.6vw, 1.5rem);
+  border-radius: 1.25rem;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  background: linear-gradient(160deg, rgba(16, 24, 39, 0.85), rgba(10, 17, 30, 0.75));
+  box-shadow: 0 18px 34px -20px rgba(6, 10, 18, 0.85);
+  backdrop-filter: blur(14px);
   --stat-color: 152 72% 47%;
 }
 
-.stat-card::before,
-.stat-card::after {
+.stat-line::before {
   content: "";
   position: absolute;
   inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(135deg, hsla(var(--stat-color) / 0.24), transparent 55%);
+  opacity: 0.6;
   pointer-events: none;
-  transition: opacity 200ms ease;
 }
 
-.stat-card::before {
-  background: radial-gradient(circle at 20% 20%, hsla(var(--stat-color) / 0.32), transparent 65%);
-  opacity: 0.75;
-}
-
-.stat-card::after {
-  background: linear-gradient(135deg, hsla(var(--stat-color) / 0.22), transparent 55%);
-  opacity: 0.45;
-}
-
-.stat-card:hover {
-  transform: translateY(-2px);
-  border-color: hsla(var(--stat-color) / 0.55);
-  box-shadow: 0 26px 56px rgba(14, 20, 33, 0.5);
-}
-
-.stat-card:hover::before {
-  opacity: 0.95;
-}
-
-.stat-card__header {
-  display: flex;
-  align-items: center;
-  gap: clamp(0.55rem, 1.4vw, 0.9rem);
-}
-
-.stat-card__indicator {
-  width: 0.75rem;
-  height: 0.75rem;
+.stat-line::after {
+  content: "";
+  position: absolute;
+  left: clamp(0.65rem, 2vw, 0.95rem);
+  top: clamp(0.8rem, 2vw, 1.1rem);
+  width: clamp(0.4rem, 0.6vw, 0.55rem);
+  height: clamp(0.4rem, 0.6vw, 0.55rem);
   border-radius: 9999px;
   background: radial-gradient(circle at 30% 30%, hsla(var(--stat-color) / 0.9), transparent 70%);
-  border: 2px solid hsla(var(--stat-color) / 0.75);
-  box-shadow: 0 0 18px hsla(var(--stat-color) / 0.55);
+  box-shadow: 0 0 14px hsla(var(--stat-color) / 0.55);
 }
 
-.stat-card__label {
-  font-size: 0.75rem;
-  letter-spacing: 0.28em;
+.stat-line__label {
+  padding-left: clamp(1.2rem, 3vw, 1.75rem);
   text-transform: uppercase;
+  letter-spacing: 0.26em;
+  font-size: 0.7rem;
+  font-weight: 600;
   color: rgba(226, 232, 240, 0.78);
   text-wrap: balance;
 }
 
-.stat-card__value {
+.stat-line__value {
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
-  gap: clamp(0.35rem, 1vw, 0.55rem);
+  align-items: flex-end;
+  gap: clamp(0.25rem, 1vw, 0.45rem);
+  text-align: right;
 }
 
-.stat-card__number {
-  font-size: clamp(2.15rem, 3.8vw, 3rem);
-  font-weight: 800;
+.stat-line__number {
+  font-size: clamp(1.55rem, 2.8vw, 2.05rem);
+  font-weight: 700;
+  letter-spacing: 0.015em;
   color: #f7fdf8;
-  text-shadow: 0 16px 34px rgba(6, 9, 16, 0.65);
-  letter-spacing: 0.01em;
-  line-height: 1.05;
+  text-shadow: 0 12px 28px rgba(6, 9, 16, 0.6);
   font-variant-numeric: tabular-nums;
 }
 
-.stat-card__meta {
-  font-size: 0.85rem;
+.stat-line__meta {
+  font-size: 0.8rem;
   font-weight: 500;
-  color: rgba(226, 232, 240, 0.72);
+  color: rgba(203, 213, 225, 0.78);
   letter-spacing: 0.02em;
 }
 
-.stat-card__meta:empty {
+.stat-line__meta:empty {
   display: none;
 }
 
-
-.stat-card[data-variant="stats.buds"] {
+.stat-line[data-variant="stats.buds"] {
   --stat-color: 150 76% 52%;
-  min-height: clamp(9rem, 17vw, 12rem);
-  padding: clamp(1.45rem, 3vw, 2.4rem);
 }
 
-.stat-card[data-variant="stats.buds"] .stat-card__number {
-  font-size: clamp(2.55rem, 4.4vw, 3.6rem);
-}
-
-.stat-card[data-variant="stats.bps"] {
+.stat-line[data-variant="stats.bps"] {
   --stat-color: 193 82% 64%;
 }
 
-.stat-card[data-variant="stats.bpc"] {
+.stat-line[data-variant="stats.bpc"] {
   --stat-color: 265 76% 66%;
 }
 
-.stat-card[data-variant="stats.total"] {
+.stat-line[data-variant="stats.total"] {
   --stat-color: 42 94% 64%;
 }
 
-.stat-card[data-variant="stats.seeds"] {
+.stat-line[data-variant="stats.seeds"] {
   --stat-color: 31 100% 65%;
 }
 
-.stat-card[data-variant="stats.prestigeMult"] {
+.stat-line[data-variant="stats.prestigeMult"] {
   --stat-color: 318 68% 66%;
-}
-
-@media (min-width: 768px) {
-  .stat-card[data-variant="stats.buds"] {
-    grid-column: span 6;
-  }
-
-  .stat-card[data-variant="stats.bps"],
-  .stat-card[data-variant="stats.bpc"] {
-    grid-column: span 3;
-  }
-
-  .stat-card[data-variant="stats.total"],
-  .stat-card[data-variant="stats.seeds"],
-  .stat-card[data-variant="stats.prestigeMult"] {
-    grid-column: span 2;
-  }
-}
-
-@media (min-width: 1280px) {
-  .stat-card[data-variant="stats.buds"] {
-    grid-column: span 6;
-    grid-row: span 2;
-  }
-
-  .stat-card[data-variant="stats.bps"] {
-    grid-column: span 3;
-  }
-
-  .stat-card[data-variant="stats.bpc"] {
-    grid-column: span 3;
-  }
-
-  .stat-card[data-variant="stats.total"],
-  .stat-card[data-variant="stats.seeds"],
-  .stat-card[data-variant="stats.prestigeMult"] {
-    grid-column: span 4;
-  }
 }
 .buy-btn {
   @apply flex h-9 items-center justify-center rounded-md bg-emerald-500 text-sm font-semibold text-neutral-900 transition hover:bg-emerald-400 focus-visible:ring-2 focus-visible:ring-emerald-300 disabled:cursor-not-allowed disabled:opacity-50;

--- a/cannaclicker/src/styles/index.css
+++ b/cannaclicker/src/styles/index.css
@@ -121,14 +121,22 @@ button {
   letter-spacing: 0.45em;
 }
 .stats-grid {
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: clamp(1rem, 2.2vw, 1.5rem);
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: clamp(1rem, 2.4vw, 1.75rem);
   align-items: stretch;
+  grid-auto-flow: dense;
+}
+
+@media (min-width: 768px) {
+  .stats-grid {
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+  }
 }
 
 @media (min-width: 1280px) {
   .stats-grid {
-    grid-template-columns: repeat(6, minmax(0, 1fr));
+    grid-template-columns: repeat(12, minmax(0, 1fr));
   }
 }
 
@@ -136,15 +144,14 @@ button {
   position: relative;
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
-  gap: 0.5rem;
-  padding: clamp(1rem, 2.5vw, 1.6rem);
-  border-radius: 1.4rem;
+  gap: clamp(0.9rem, 1.8vw, 1.4rem);
+  padding: clamp(1.15rem, 2.6vw, 2rem);
+  border-radius: 1.6rem;
   border: 1px solid rgba(255, 255, 255, 0.08);
-  background: linear-gradient(150deg, rgba(17, 24, 39, 0.78), rgba(12, 19, 32, 0.72));
-  box-shadow: 0 24px 48px rgba(10, 12, 21, 0.45);
+  background: linear-gradient(158deg, rgba(15, 23, 42, 0.9), rgba(11, 18, 32, 0.78));
+  box-shadow: 0 26px 52px rgba(10, 12, 21, 0.5);
   backdrop-filter: blur(18px);
-  min-height: clamp(6.25rem, 10vw, 7.5rem);
+  min-height: clamp(7.25rem, 11vw, 9.5rem);
   overflow: hidden;
   transition: transform 160ms ease, border-color 160ms ease, box-shadow 160ms ease;
   --stat-color: 152 72% 47%;
@@ -179,24 +186,66 @@ button {
   opacity: 0.95;
 }
 
+.stat-card__header {
+  display: flex;
+  align-items: center;
+  gap: clamp(0.55rem, 1.4vw, 0.9rem);
+}
+
+.stat-card__indicator {
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 9999px;
+  background: radial-gradient(circle at 30% 30%, hsla(var(--stat-color) / 0.9), transparent 70%);
+  border: 2px solid hsla(var(--stat-color) / 0.75);
+  box-shadow: 0 0 18px hsla(var(--stat-color) / 0.55);
+}
+
 .stat-card__label {
-  font-size: 0.68rem;
-  letter-spacing: 0.35em;
+  font-size: 0.75rem;
+  letter-spacing: 0.28em;
   text-transform: uppercase;
-  color: rgba(226, 232, 240, 0.7);
+  color: rgba(226, 232, 240, 0.78);
+  text-wrap: balance;
 }
 
 .stat-card__value {
-  font-size: clamp(1.85rem, 3.1vw, 2.6rem);
-  font-weight: 700;
-  color: #f7fdf8;
-  text-shadow: 0 10px 24px rgba(0, 0, 0, 0.5);
-  line-height: 1.05;
-  letter-spacing: 0.015em;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: clamp(0.35rem, 1vw, 0.55rem);
 }
+
+.stat-card__number {
+  font-size: clamp(2.15rem, 3.8vw, 3rem);
+  font-weight: 800;
+  color: #f7fdf8;
+  text-shadow: 0 16px 34px rgba(6, 9, 16, 0.65);
+  letter-spacing: 0.01em;
+  line-height: 1.05;
+  font-variant-numeric: tabular-nums;
+}
+
+.stat-card__meta {
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: rgba(226, 232, 240, 0.72);
+  letter-spacing: 0.02em;
+}
+
+.stat-card__meta:empty {
+  display: none;
+}
+
 
 .stat-card[data-variant="stats.buds"] {
   --stat-color: 150 76% 52%;
+  min-height: clamp(9rem, 17vw, 12rem);
+  padding: clamp(1.45rem, 3vw, 2.4rem);
+}
+
+.stat-card[data-variant="stats.buds"] .stat-card__number {
+  font-size: clamp(2.55rem, 4.4vw, 3.6rem);
 }
 
 .stat-card[data-variant="stats.bps"] {
@@ -217,6 +266,44 @@ button {
 
 .stat-card[data-variant="stats.prestigeMult"] {
   --stat-color: 318 68% 66%;
+}
+
+@media (min-width: 768px) {
+  .stat-card[data-variant="stats.buds"] {
+    grid-column: span 6;
+  }
+
+  .stat-card[data-variant="stats.bps"],
+  .stat-card[data-variant="stats.bpc"] {
+    grid-column: span 3;
+  }
+
+  .stat-card[data-variant="stats.total"],
+  .stat-card[data-variant="stats.seeds"],
+  .stat-card[data-variant="stats.prestigeMult"] {
+    grid-column: span 2;
+  }
+}
+
+@media (min-width: 1280px) {
+  .stat-card[data-variant="stats.buds"] {
+    grid-column: span 6;
+    grid-row: span 2;
+  }
+
+  .stat-card[data-variant="stats.bps"] {
+    grid-column: span 3;
+  }
+
+  .stat-card[data-variant="stats.bpc"] {
+    grid-column: span 3;
+  }
+
+  .stat-card[data-variant="stats.total"],
+  .stat-card[data-variant="stats.seeds"],
+  .stat-card[data-variant="stats.prestigeMult"] {
+    grid-column: span 4;
+  }
 }
 .buy-btn {
   @apply flex h-9 items-center justify-center rounded-md bg-emerald-500 text-sm font-semibold text-neutral-900 transition hover:bg-emerald-400 focus-visible:ring-2 focus-visible:ring-emerald-300 disabled:cursor-not-allowed disabled:opacity-50;


### PR DESCRIPTION
## Summary
- redesign the stats header into semantic cards with localized captions and indicator accents
- add localized meta descriptions for each stat to clarify what the numbers represent
- refresh the responsive layout and styling so the statistics remain legible across breakpoints

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce90546484832d8063cb5993d817a4