### PR TITLE
Redesign top stats ribbon and resize header

### DIFF
--- a/cannaclicker/src/app/ui.ts
+++ b/cannaclicker/src/app/ui.ts
@@ -274,7 +274,6 @@ function buildUI(state: GameState): UIRefs {
   const layout = document.createElement("div");
   layout.className =
     "grid gap-4 lg:grid-cols-[minmax(0,1.05fr)_minmax(0,0.95fr)] xl:gap-6 2xl:gap-8";
-  root.appendChild(layout);
 
   const primaryColumn = document.createElement("div");
   primaryColumn.className = "space-y-4";
@@ -284,49 +283,58 @@ function buildUI(state: GameState): UIRefs {
 
   layout.append(primaryColumn, secondaryColumn);
 
-  const headerCard = document.createElement("section");
-  headerCard.className = "card fade-in space-y-3";
-
-  const title = document.createElement("h1");
-  title.className = "text-4xl md:text-5xl font-extrabold tracking-tight text-leaf-200 drop-shadow-[0_14px_28px_rgba(16,185,129,0.35)]";
-  title.textContent = "CannaBies";
-  headerCard.appendChild(title);
-
-  const statsList = document.createElement("div");
-  statsList.className = "stats-bar";
-  headerCard.appendChild(statsList);
-
   const statsLabels = new Map<string, HTMLElement>();
   const statsMeta = new Map<string, HTMLElement>();
 
-  const budsStat = createStatBlock("stats.buds", statsList, statsLabels, statsMeta);
-  const bpsStat = createStatBlock("stats.bps", statsList, statsLabels, statsMeta);
-  const bpcStat = createStatBlock("stats.bpc", statsList, statsLabels, statsMeta);
-  const totalStat = createStatBlock("stats.total", statsList, statsLabels, statsMeta);
-  const seedsStat = createStatBlock("stats.seeds", statsList, statsLabels, statsMeta);
+  const infoRibbon = document.createElement("section");
+  infoRibbon.className = "info-ribbon fade-in";
+
+  const infoList = document.createElement("div");
+  infoList.className = "info-ribbon__list";
+  infoRibbon.appendChild(infoList);
+
+  const totalStat = createStatBlock("stats.total", infoList, statsLabels, statsMeta);
+  const seedsStat = createStatBlock("stats.seeds", infoList, statsLabels, statsMeta);
   const prestigeStat = createStatBlock(
     "stats.prestigeMult",
-    statsList,
+    infoList,
     statsLabels,
     statsMeta,
   );
 
-  const seedBadge = document.createElement('button');
-  seedBadge.type = 'button';
-  seedBadge.className = 'inline-flex items-center gap-2 self-start rounded-full border border-emerald-400/40 bg-emerald-500/10 px-3 py-1 text-sm font-semibold text-emerald-100 transition hover:border-emerald-300/60 hover:bg-emerald-500/20 focus-visible:ring-2 focus-visible:ring-emerald-300/60 focus-visible:ring-offset-0';
+  const infoActions = document.createElement("div");
+  infoActions.className = "info-ribbon__actions";
+  infoRibbon.appendChild(infoActions);
+
+  const seedBadge = document.createElement("button");
+  seedBadge.type = "button";
+  seedBadge.className = "prestige-badge";
   const seedIcon = new Image();
-  seedIcon.src = withBase('icons/ui/ui-save.png');
-  seedIcon.alt = '';
-  seedIcon.decoding = 'async';
-  seedIcon.className = 'h-4 w-4';
-  const seedBadgeValue = document.createElement('span');
-  seedBadgeValue.className = 'tabular-nums';
+  seedIcon.src = withBase("icons/ui/ui-save.png");
+  seedIcon.alt = "";
+  seedIcon.decoding = "async";
+  seedIcon.className = "prestige-badge__icon";
+  const seedBadgeValue = document.createElement("span");
+  seedBadgeValue.className = "prestige-badge__value";
   seedBadge.append(seedIcon, seedBadgeValue);
-  headerCard.appendChild(seedBadge);
-  primaryColumn.appendChild(headerCard);
+  infoActions.appendChild(seedBadge);
+  root.append(infoRibbon, layout);
+
+  const title = document.createElement("h1");
+  title.className = "click-card__title";
+  title.textContent = "CannaBies";
 
   const clickCard = document.createElement("section");
-  clickCard.className = "card fade-in space-y-4";
+  clickCard.className = "card fade-in click-card";
+
+  const clickHeader = document.createElement("div");
+  clickHeader.className = "click-card__header";
+  clickHeader.appendChild(title);
+  clickCard.appendChild(clickHeader);
+
+  const clickBody = document.createElement("div");
+  clickBody.className = "click-card__body";
+  clickCard.appendChild(clickBody);
 
   const clickButton = document.createElement("button");
   clickButton.className = "click-button w-full";
@@ -347,8 +355,15 @@ function buildUI(state: GameState): UIRefs {
   clickLabel.className = "click-label";
 
   clickButton.append(clickIcon, clickLabel);
+  clickBody.appendChild(clickButton);
 
-  clickCard.appendChild(clickButton);
+  const clickStats = document.createElement("div");
+  clickStats.className = "click-stats";
+  clickBody.appendChild(clickStats);
+
+  const budsStat = createStatBlock("stats.buds", clickStats, statsLabels, statsMeta);
+  const bpsStat = createStatBlock("stats.bps", clickStats, statsLabels, statsMeta);
+  const bpcStat = createStatBlock("stats.bpc", clickStats, statsLabels, statsMeta);
 
   const announcer = document.createElement("p");
   announcer.setAttribute("data-sr-only", "true");
@@ -450,34 +465,34 @@ function buildUI(state: GameState): UIRefs {
 function mountHeader(root: HTMLElement, controls: HTMLButtonElement[]): void {
   const header = document.createElement("header");
   header.className =
-    "flex w-full flex-col items-start gap-4 rounded-3xl border border-white/10 bg-neutral-900/80 px-4 py-4 shadow-[0_24px_60px_rgba(10,12,21,0.55)] backdrop-blur-xl sm:flex-row sm:items-center sm:justify-between sm:gap-6 sm:px-6 lg:px-8";
+    "flex w-full flex-col items-start gap-3 rounded-3xl border border-white/10 bg-neutral-900/80 px-4 py-3 shadow-[0_20px_48px_rgba(10,12,21,0.5)] backdrop-blur-xl sm:flex-row sm:items-center sm:justify-between sm:gap-4 sm:px-5 lg:px-6";
 
   const brand = document.createElement("div");
   brand.className =
-    "flex items-center gap-4 md:gap-6 rounded-2xl bg-gradient-to-br from-neutral-900/90 via-neutral-900/75 to-neutral-800/75 px-4 md:px-6 py-4 shadow-[0_24px_48px_rgba(16,185,129,0.28)] ring-1 ring-emerald-400/25 backdrop-blur";
+    "flex items-center gap-3 md:gap-5 rounded-2xl bg-gradient-to-br from-neutral-900/90 via-neutral-900/75 to-neutral-800/75 px-4 md:px-5 py-3 shadow-[0_18px_38px_rgba(16,185,129,0.28)] ring-1 ring-emerald-400/25 backdrop-blur";
 
   const leafWrap = document.createElement("span");
   leafWrap.className =
-    "relative grid h-14 w-14 place-items-center rounded-2xl bg-gradient-to-br from-lime-300/35 via-emerald-300/25 to-emerald-500/30 shadow-[0_0_38px_rgba(202,255,120,0.55)] ring-1 ring-lime-200/35";
+    "relative grid h-12 w-12 place-items-center rounded-2xl bg-gradient-to-br from-lime-300/35 via-emerald-300/25 to-emerald-500/30 shadow-[0_0_28px_rgba(202,255,120,0.5)] ring-1 ring-lime-200/35";
 
   const leaf = new Image();
   leaf.src = withBase("img/logo-leaf.svg");
   leaf.alt = "";
   leaf.decoding = "async";
   leaf.className =
-    "h-12 w-12 drop-shadow-[0_18px_34px_rgba(202,255,150,0.6)] saturate-150 brightness-110";
+    "h-10 w-10 drop-shadow-[0_14px_28px_rgba(202,255,150,0.6)] saturate-150 brightness-110";
 
   leafWrap.appendChild(leaf);
 
   const brandText = document.createElement("div");
-  brandText.className = "flex flex-col justify-center gap-1 pl-2";
+  brandText.className = "flex flex-col justify-center gap-1 pl-1";
 
   const wordmark = new Image();
   wordmark.src = withBase("img/logo-wordmark.svg");
   wordmark.alt = "CannaClicker wordmark";
   wordmark.decoding = "async";
   wordmark.className =
-    "relative left-4 top-2 h-24 w-auto drop-shadow-[0_26px_46px_rgba(56,220,120,0.6)] saturate-150 contrast-125 md:left-6 md:top-2";
+    "relative left-2 top-1 h-16 w-auto drop-shadow-[0_22px_42px_rgba(56,220,120,0.55)] saturate-150 contrast-125 md:left-4 md:top-0 md:h-20";
 
   brandText.append(wordmark);
 
@@ -485,7 +500,7 @@ function mountHeader(root: HTMLElement, controls: HTMLButtonElement[]): void {
 
   const actionWrap = document.createElement("div");
   actionWrap.className =
-    "flex flex-nowrap items-center gap-3 overflow-x-auto rounded-2xl border border-white/10 bg-neutral-900/70 px-3 py-2 shadow-[0_22px_44px_rgba(10,12,21,0.5)] ring-1 ring-white/10 backdrop-blur sm:px-4";
+    "flex flex-nowrap items-center gap-2.5 overflow-x-auto rounded-2xl border border-white/10 bg-neutral-900/70 px-3 py-1.5 shadow-[0_18px_36px_rgba(10,12,21,0.45)] ring-1 ring-white/10 backdrop-blur sm:px-3.5";
   controls.forEach((control) => {
     control.classList.add("shrink-0");
     actionWrap.append(control);

--- a/cannaclicker/src/styles/index.css
+++ b/cannaclicker/src/styles/index.css
@@ -126,10 +126,6 @@ button {
   gap: clamp(0.6rem, 1.6vw, 1rem);
 }
 
-.stats-bar {
-  @apply flex flex-wrap items-center gap-4 md:gap-6 lg:gap-8;
-}
-
 .stat-item {
   @apply flex items-center gap-3 rounded-lg border border-white/10 bg-neutral-900/60 px-4 py-2 transition hover:bg-neutral-900/80;
   min-width: 0;
@@ -153,6 +149,136 @@ button {
 .stat-item__value {
   @apply text-sm font-bold text-white tabular-nums;
   text-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+}
+
+.info-ribbon {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: clamp(0.85rem, 2vw, 1.4rem);
+  padding: clamp(0.9rem, 2.2vw, 1.3rem) clamp(1.1rem, 2.6vw, 1.8rem);
+  border-radius: 1.75rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.78), rgba(8, 14, 27, 0.85));
+  box-shadow: 0 22px 48px -26px rgba(6, 10, 18, 0.9);
+  backdrop-filter: blur(18px);
+}
+
+.info-ribbon__list {
+  display: flex;
+  flex: 1 1 16rem;
+  flex-wrap: wrap;
+  align-items: stretch;
+  gap: clamp(0.6rem, 1.6vw, 1rem);
+}
+
+.info-ribbon__list .stat-item {
+  @apply bg-neutral-900/50 border-white/10 px-4 py-3;
+  flex: 1 1 14rem;
+  border-radius: 1.25rem;
+  background-image: linear-gradient(140deg, rgba(30, 64, 175, 0.08), rgba(6, 95, 70, 0.08));
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02), 0 16px 32px -26px rgba(6, 10, 18, 0.9);
+}
+
+.info-ribbon__actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  flex: 0 0 auto;
+}
+
+.prestige-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  border-radius: 9999px;
+  border: 1px solid rgba(74, 222, 128, 0.35);
+  background: linear-gradient(135deg, rgba(13, 148, 136, 0.3), rgba(21, 128, 61, 0.25));
+  padding: 0.45rem 0.9rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: hsl(152 76% 85%);
+  box-shadow: 0 18px 38px -24px rgba(16, 185, 129, 0.6);
+  transition: border-color 200ms ease, background 200ms ease, transform 200ms ease;
+}
+
+.prestige-badge:hover {
+  border-color: rgba(74, 222, 128, 0.55);
+  background: linear-gradient(135deg, rgba(13, 148, 136, 0.42), rgba(21, 128, 61, 0.38));
+  transform: translateY(-1px);
+}
+
+.prestige-badge:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(16, 185, 129, 0.45);
+}
+
+.prestige-badge__icon {
+  width: 1.05rem;
+  height: 1.05rem;
+  filter: drop-shadow(0 0 8px rgba(16, 185, 129, 0.45));
+}
+
+.prestige-badge__value {
+  @apply tabular-nums;
+  font-variant-numeric: tabular-nums;
+}
+
+.click-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  padding: 0;
+  overflow: hidden;
+}
+
+.click-card__header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: clamp(1.1rem, 2.6vw, 1.6rem) clamp(1.2rem, 3vw, 2rem) clamp(0.6rem, 1.8vw, 0.9rem);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.92), rgba(6, 11, 21, 0.75));
+}
+
+.click-card__title {
+  @apply text-3xl md:text-4xl font-extrabold tracking-tight text-leaf-200;
+  text-shadow: 0 16px 34px rgba(16, 185, 129, 0.35);
+}
+
+.click-card__body {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.5rem, 3.5vw, 2.25rem);
+  padding: clamp(1.25rem, 3.2vw, 2.2rem) clamp(1.1rem, 3vw, 2rem) clamp(2.5rem, 5vw, 3rem);
+}
+
+.click-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: clamp(0.75rem, 2vw, 1.25rem);
+  margin-top: clamp(-2.25rem, -5vw, -1.5rem);
+}
+
+.click-stats .stat-item {
+  position: relative;
+  @apply border-white/10 bg-neutral-900/70 px-4 py-3;
+  border-radius: 1.35rem;
+  background-image: linear-gradient(145deg, rgba(5, 150, 105, 0.15), rgba(30, 64, 175, 0.12));
+  box-shadow: 0 24px 48px -26px rgba(9, 17, 29, 0.85);
+}
+
+.click-stats .stat-item::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: radial-gradient(circle at top right, rgba(34, 197, 94, 0.3), transparent 60%);
+  opacity: 0.6;
+  mix-blend-mode: screen;
+  pointer-events: none;
 }
 
 .stat-item[data-variant="stats.buds"] .stat-item__icon {


### PR DESCRIPTION
## Summary
- reorganized the former CannaBies box into a horizontal info ribbon with prestige badge actions
- restyled the click card to house the title and bud-related stats alongside the plant button
- tightened header spacing and control styling to shrink the masthead height

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ceddf8f318832db76a982ff8f170ff