### PR TITLE
Reduce info ribbon spacing

### DIFF
--- a/cannaclicker/src/styles/index.css
+++ b/cannaclicker/src/styles/index.css
@@ -155,8 +155,8 @@ button {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: clamp(0.6rem, 1.6vw, 1rem);
-  padding: clamp(0.65rem, 1.6vw, 1rem) clamp(0.85rem, 2.1vw, 1.4rem);
+  gap: clamp(0.45rem, 1.1vw, 0.75rem);
+  padding: clamp(0.45rem, 1.2vw, 0.75rem) clamp(0.7rem, 1.8vw, 1.1rem);
   border-radius: 1.35rem;
   border: 1px solid rgba(255, 255, 255, 0.08);
   background: linear-gradient(135deg, rgba(15, 23, 42, 0.78), rgba(8, 14, 27, 0.85));
@@ -169,12 +169,12 @@ button {
   flex: 1 1 16rem;
   flex-wrap: wrap;
   align-items: stretch;
-  gap: clamp(0.45rem, 1.2vw, 0.75rem);
+  gap: clamp(0.3rem, 0.8vw, 0.5rem);
 }
 
 .info-ribbon__list .stat-item {
-  @apply bg-neutral-900/50 border-white/10 px-3.5 py-2.5;
-  flex: 1 1 14rem;
+  @apply bg-neutral-900/50 border-white/10 px-3 py-2;
+  flex: 1 1 13rem;
   border-radius: 1.05rem;
   background-image: linear-gradient(140deg, rgba(30, 64, 175, 0.07), rgba(6, 95, 70, 0.07));
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02), 0 12px 28px -28px rgba(6, 10, 18, 0.9);


### PR DESCRIPTION
## Summary
- decrease the info ribbon padding and internal gap spacing to make the banner more compact
- tighten the stat card padding and basis sizing to shrink the green stat blocks

## Testing
- `npm run lint` *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cfcc8c818c832db2ac18b9fe1802a9