### PR TITLE
Fix shop card hover flicker by stabilizing DOM order

### DIFF
--- a/cannaclicker/src/app/ui.ts
+++ b/cannaclicker/src/app/ui.ts
@@ -953,7 +953,7 @@ function updateShop(state: GameState): void {
   const entries = getShopEntries(state);
   const sorted = sortShopEntries(entries, state.preferences.shopSortMode);
 
-  sorted.forEach((entry) => {
+  sorted.forEach((entry, index) => {
     let card = refs!.shopEntries.get(entry.definition.id);
     if (!card) {
       card = createShopCard(entry.definition.id, state);
@@ -1018,7 +1018,11 @@ function updateShop(state: GameState): void {
     card.owned.textContent = entry.owned.toString();
     card.payback.textContent = formatPayback(state.locale, entry.payback);
 
-    refs.sidePanel.shop.list.appendChild(card.container);
+    const list = refs.sidePanel.shop.list;
+    const currentChild = list.children.item(index);
+    if (currentChild !== card.container) {
+      list.insertBefore(card.container, currentChild ?? null);
+    }
   });
 }
 
@@ -1717,8 +1721,6 @@ function createShopCard(itemId: string, state: GameState): ShopCardRefs {
   media.appendChild(icon);
 
   container.append(info, media);
-  refs.sidePanel.shop.list.appendChild(container);
-
   buyButton.addEventListener("click", () => {
     if (buyItem(state, itemId, 1)) {
       audio.playPurchase();


### PR DESCRIPTION
## Summary
- prevent the shop list from re-appending cards on every render to avoid hover flicker
- insert cards in their sorted position only when their order actually changes
- rely on render-time insertion so newly created cards still mount correctly without duplicate appends

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d01b16498c832d89e8818f74a03c3b