### PR TITLE
Remove prestige header button and darken UI visuals

### DIFF
--- a/cannaclicker/src/styles/index.css
+++ b/cannaclicker/src/styles/index.css
@@ -42,7 +42,10 @@ button {
 }
 
 .icon-badge {
-  @apply inline-flex items-center justify-center rounded-md border border-white/10 bg-neutral-900/70 p-1 shadow-inner;
+  @apply inline-flex items-center justify-center rounded-md border p-1 shadow-inner;
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.92), rgba(8, 14, 27, 0.88));
+  border-color: rgba(148, 163, 184, 0.18);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08), 0 12px 26px rgba(2, 6, 23, 0.45);
 }
 
 .icon-img {
@@ -51,8 +54,10 @@ button {
 }
 
 .control-icon-badge {
-  @apply bg-neutral-900/80 border-white/15 p-1.5;
-  box-shadow: 0 10px 22px rgba(0, 0, 0, 0.35), inset 0 0 0 1px rgba(255, 255, 255, 0.06);
+  @apply border p-1.5;
+  background: linear-gradient(140deg, rgba(15, 23, 42, 0.94), rgba(8, 14, 27, 0.92));
+  border-color: rgba(148, 163, 184, 0.2);
+  box-shadow: 0 14px 28px rgba(2, 6, 23, 0.5), inset 0 0 0 1px rgba(255, 255, 255, 0.06);
 }
 
 .control-icon-img {
@@ -127,14 +132,33 @@ button {
 }
 
 .stat-item {
-  @apply flex items-center gap-3 rounded-lg border border-white/10 bg-neutral-900/60 px-4 py-2 transition hover:bg-neutral-900/80;
+  @apply flex items-center gap-3 rounded-xl border px-4 py-2 transition;
   min-width: 0;
   flex: 0 1 auto;
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.9), rgba(8, 15, 30, 0.88));
+  border-color: rgba(148, 163, 184, 0.18);
+  box-shadow: 0 18px 36px -26px rgba(2, 6, 23, 0.85);
+  backdrop-filter: blur(12px);
+}
+
+.stat-item:hover {
+  border-color: rgba(16, 185, 129, 0.45);
+  transform: translateY(-1px);
+}
+
+.stat-item__icon-wrap {
+  @apply grid h-10 w-10 place-items-center rounded-full border;
+  background: radial-gradient(circle at 30% 30%, rgba(32, 197, 94, 0.28), transparent 68%),
+    linear-gradient(140deg, rgba(10, 20, 38, 0.96), rgba(8, 14, 27, 0.9));
+  border-color: rgba(148, 163, 184, 0.24);
+  box-shadow: 0 14px 30px rgba(2, 6, 23, 0.55), inset 0 1px 0 rgba(255, 255, 255, 0.08);
 }
 
 .stat-item__icon {
-  @apply h-5 w-5 flex-shrink-0;
-  filter: drop-shadow(0 0 4px rgba(0, 0, 0, 0.5));
+  @apply h-5 w-5;
+  display: block;
+  object-fit: contain;
+  filter: drop-shadow(0 0 4px rgba(0, 0, 0, 0.45));
 }
 
 .stat-item__content {
@@ -173,11 +197,12 @@ button {
 }
 
 .info-ribbon__list .stat-item {
-  @apply bg-neutral-900/50 border-white/10 px-3 py-2;
+  @apply px-3 py-2;
   flex: 1 1 13rem;
   border-radius: 1.05rem;
-  background-image: linear-gradient(140deg, rgba(30, 64, 175, 0.07), rgba(6, 95, 70, 0.07));
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02), 0 12px 28px -28px rgba(6, 10, 18, 0.9);
+  background: linear-gradient(150deg, rgba(15, 23, 42, 0.92), rgba(8, 14, 27, 0.88));
+  border-color: rgba(148, 163, 184, 0.2);
+  box-shadow: 0 18px 36px -28px rgba(2, 6, 23, 0.8);
 }
 
 .info-ribbon__actions {
@@ -212,6 +237,12 @@ button {
 .prestige-badge:focus-visible {
   outline: none;
   box-shadow: 0 0 0 2px rgba(16, 185, 129, 0.45);
+}
+
+.prestige-badge.is-ready {
+  border-color: rgba(74, 222, 128, 0.65);
+  background: linear-gradient(135deg, rgba(16, 185, 129, 0.4), rgba(22, 163, 74, 0.35));
+  box-shadow: 0 20px 38px -28px rgba(16, 185, 129, 0.65);
 }
 
 .prestige-badge__icon {
@@ -346,10 +377,11 @@ button {
 
 .click-stats .stat-item {
   position: relative;
-  @apply border-white/10 bg-neutral-900/70 px-4 py-3;
+  @apply px-4 py-3;
   border-radius: 1.35rem;
-  background-image: linear-gradient(145deg, rgba(5, 150, 105, 0.15), rgba(30, 64, 175, 0.12));
-  box-shadow: 0 24px 48px -26px rgba(9, 17, 29, 0.85);
+  background: linear-gradient(160deg, rgba(15, 23, 42, 0.94), rgba(6, 12, 24, 0.88));
+  border-color: rgba(148, 163, 184, 0.22);
+  box-shadow: 0 26px 52px -28px rgba(2, 6, 23, 0.85);
 }
 
 .click-stats .stat-item::after {
@@ -357,8 +389,8 @@ button {
   position: absolute;
   inset: 0;
   border-radius: inherit;
-  background: radial-gradient(circle at top right, rgba(34, 197, 94, 0.3), transparent 60%);
-  opacity: 0.6;
+  background: radial-gradient(circle at top right, rgba(34, 197, 94, 0.25), transparent 65%);
+  opacity: 0.4;
   mix-blend-mode: screen;
   pointer-events: none;
 }
@@ -509,11 +541,14 @@ button {
 }
 
 .ability-btn {
-  @apply relative flex flex-col gap-2 rounded-xl border border-white/10 bg-neutral-900/70 px-4 py-4 text-left shadow-card transition;
+  @apply relative flex flex-col gap-2 rounded-xl border px-4 py-4 text-left transition;
+  background: linear-gradient(155deg, rgba(15, 23, 42, 0.94), rgba(7, 13, 26, 0.9));
+  border-color: rgba(148, 163, 184, 0.22);
+  box-shadow: 0 22px 48px -30px rgba(2, 6, 23, 0.75);
 }
 
 .ability-btn:hover:not(:disabled) {
-  @apply border-emerald-400/50;
+  border-color: rgba(16, 185, 129, 0.45);
   transform: translateY(-1px);
 }
 
@@ -530,7 +565,8 @@ button {
 }
 
 .ability-btn.is-cooldown {
-  @apply border-white/10 bg-neutral-900/60;
+  @apply border-white/10;
+  background: linear-gradient(150deg, rgba(15, 23, 42, 0.9), rgba(7, 12, 24, 0.86));
 }
 
 .ability-header {
@@ -538,11 +574,16 @@ button {
 }
 
 .ability-icon {
-  @apply flex h-12 w-12 items-center justify-center rounded-xl bg-neutral-800/80;
+  @apply flex h-12 w-12 items-center justify-center rounded-xl border;
+  background: linear-gradient(145deg, rgba(10, 20, 38, 0.96), rgba(6, 12, 23, 0.9));
+  border-color: rgba(148, 163, 184, 0.24);
+  box-shadow: 0 16px 32px rgba(2, 6, 23, 0.55), inset 0 1px 0 rgba(255, 255, 255, 0.08);
 }
 
 .ability-icon-img {
   @apply h-10 w-10 object-contain;
+  display: block;
+  filter: drop-shadow(0 0 6px rgba(0, 0, 0, 0.4));
 }
 
 .ability-meta {


### PR DESCRIPTION
## Summary
- remove the prestige shortcut from the header and let the seed badge open the prestige modal with readiness feedback
- wrap statistic icons and tweak prestige tooltip handling for darker, cleaner stat displays
- overhaul control, stat, and ability styling so previously white icon backgrounds render with rich dark gradients

## Testing
- npm run lint *(fails: pre-existing lint errors in save.ts and abilities.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68d023ee3084832db0e24083932a2023