### PR TITLE
feat: add high-tier cultivation shop items

### DIFF
--- a/cannaclicker/src/data/items.ts
+++ b/cannaclicker/src/data/items.ts
@@ -118,6 +118,146 @@ export const items: ItemDefinition[] = [
     softcapTier: 8,
     softcapMult: 1.1,
   },
+  {
+    id: 'irrigation_system',
+    name: {
+      de: 'Bewässerungssystem',
+      en: 'Irrigation System',
+    },
+    description: {
+      de: 'Automatisch gießen, niemals vergessen.',
+      en: 'Automatic watering, never forget again.',
+    },
+    baseCost: 700_000,
+    costFactor: 1.28,
+    bps: 1_300,
+    icon: asset('img/bewasesserung_shop.png'),
+    unlock: {
+      totalBuds: 500_000,
+    },
+    softcapTier: 8,
+    softcapMult: 1.1,
+  },
+  {
+    id: 'co2_tank',
+    name: {
+      de: 'CO₂-Tank',
+      en: 'CO₂ Tank',
+    },
+    description: {
+      de: 'Mehr CO₂, mehr Fotosynthese.',
+      en: 'More CO₂, more photosynthesis.',
+    },
+    baseCost: 3_500_000,
+    costFactor: 1.28,
+    bps: 6_500,
+    icon: asset('img/co2tank_shop.png'),
+    unlock: {
+      totalBuds: 3_000_000,
+    },
+    softcapTier: 8,
+    softcapMult: 1.1,
+  },
+  {
+    id: 'climate_controller',
+    name: {
+      de: 'Klima-Controller',
+      en: 'Climate Controller',
+    },
+    description: {
+      de: 'Temp und Luftfeuchte auf Punkt.',
+      en: 'Temperature and humidity dialed in.',
+    },
+    baseCost: 15_000_000,
+    costFactor: 1.29,
+    bps: 28_000,
+    icon: asset('img/KlimaController_shop.png'),
+    unlock: {
+      totalBuds: 12_000_000,
+    },
+    softcapTier: 9,
+    softcapMult: 1.12,
+  },
+  {
+    id: 'hydroponic_rack',
+    name: {
+      de: 'Hydroponik-Rack',
+      en: 'Hydroponic Rack',
+    },
+    description: {
+      de: 'Wurzeln lieben es.',
+      en: 'Roots love it.',
+    },
+    baseCost: 80_000_000,
+    costFactor: 1.3,
+    bps: 150_000,
+    icon: asset('img/hydroponik_shop.png'),
+    unlock: {
+      totalBuds: 60_000_000,
+    },
+    softcapTier: 9,
+    softcapMult: 1.12,
+  },
+  {
+    id: 'genetics_lab',
+    name: {
+      de: 'Genetik-Labor',
+      en: 'Genetics Lab',
+    },
+    description: {
+      de: 'Strains tunen.',
+      en: 'Tune your strains.',
+    },
+    baseCost: 400_000_000,
+    costFactor: 1.31,
+    bps: 800_000,
+    icon: asset('img/genetik_shop.png'),
+    unlock: {
+      totalBuds: 300_000_000,
+    },
+    softcapTier: 10,
+    softcapMult: 1.13,
+  },
+  {
+    id: 'trimming_robot',
+    name: {
+      de: 'Trimm-Roboter',
+      en: 'Trimming Robot',
+    },
+    description: {
+      de: 'Schneidet Tag und Nacht.',
+      en: 'Trims day and night.',
+    },
+    baseCost: 2_000_000_000,
+    costFactor: 1.31,
+    bps: 4_000_000,
+    icon: asset('img/roboter_shop.png'),
+    unlock: {
+      totalBuds: 1_500_000_000,
+    },
+    softcapTier: 10,
+    softcapMult: 1.13,
+  },
+  {
+    id: 'micro_greenhouse',
+    name: {
+      de: 'Mikro-Gewächshaus',
+      en: 'Micro Greenhouse',
+    },
+    description: {
+      de: 'Mikroklima, Makro-Output.',
+      en: 'Microclimate, macro output.',
+    },
+    baseCost: 12_000_000_000,
+    costFactor: 1.33,
+    bps: 24_000_000,
+    icon: asset('img/gewaechshaus_shop.png'),
+    unlock: {
+      totalBuds: 8_000_000_000,
+    },
+    softcapTier: 10,
+    softcapMult: 1.13,
+  },
 ];
 
 export const itemById = new Map(items.map((item) => [item.id, item] as const));


### PR DESCRIPTION
## Summary
- extend the shop item list to include seven new late-game purchases with localized names and descriptions
- wire each new item to its existing artwork and configure unlock thresholds, costs, BPS gains, and softcap behaviour

## Testing
- npm run lint *(fails: existing lint errors in src/app/save.ts and src/data/abilities.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68d057b6503c832db9152511b2345d6b