### PR TITLE
Fix prestige seed display formatting

### DIFF
--- a/cannaclicker/src/app/ui.ts
+++ b/cannaclicker/src/app/ui.ts
@@ -1011,12 +1011,13 @@ function updateStats(state: GameState): void {
   refs.bps.textContent = formatDecimal(state.bps);
   refs.bpc.textContent = formatDecimal(state.bpc);
   refs.total.textContent = formatDecimal(state.total);
-  refs.seeds.textContent = formatDecimal(state.prestige.seeds);
+  const seedText = formatInteger(state.locale, state.prestige.seeds);
+  refs.seeds.textContent = seedText;
   const seedRateValue = formatSeedRate(state.locale, state.temp.seedRatePerHour ?? 0);
   refs.seedRate.textContent = seedRateValue;
   refs.prestigeMult.textContent = `${state.prestige.mult.toFixed(2)}\u00D7`;
 
-  refs.seedBadgeValue.textContent = formatDecimal(state.prestige.seeds);
+  refs.seedBadgeValue.textContent = seedText;
   const seedRateMeta = refs.statsMeta.get("stats.seedRate");
   if (seedRateMeta) {
     if (state.temp.seedPassiveThrottled) {


### PR DESCRIPTION
## Summary
- display prestige seeds as whole numbers in the main stats and prestige badge so the prestige currency no longer shows decimal fractions

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d179371798832db72b1f690c29c449