### PR TITLE
Fix migrations milestone import path

### DIFF
--- a/cannaclicker/src/app/save/migrations.ts
+++ b/cannaclicker/src/app/save/migrations.ts
@@ -8,7 +8,7 @@ import {
   SAVE_VERSION,
 } from '../state';
 import { createDefaultSettings, type SettingsState } from '../settings';
-import { milestones } from '../data/milestones';
+import { milestones } from '../../data/milestones';
 import { getKickstartConfig } from '../milestones';
 import type {
   PersistedAbilityRecord,


### PR DESCRIPTION
## Summary
- fix the relative import to milestones in the save migrations module so Vite can resolve it during builds

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d51f4e2e90832d92e9780f8f22fb19