### PR TITLE
Fix UI barrel exports to unblock build

### DIFF
--- a/cannaclicker/src/app/ui/index.ts
+++ b/cannaclicker/src/app/ui/index.ts
@@ -1,2 +1,5 @@
+export { startUI } from './start';
+export type { UIInitResult } from './bootstrap';
+export type { UITicker } from './start';
 export { initUI } from './bootstrap';
-export type { InitI18nApi, UIInitResult } from './bootstrap';
+export type { InitI18nApi } from './bootstrap';

--- a/cannaclicker/src/app/ui/start.ts
+++ b/cannaclicker/src/app/ui/start.ts
@@ -1,11 +1,10 @@
-import { createAudioManager } from './audio';
-import { t } from './i18n';
-import { evaluateAchievements, recalcDerivedValues } from './game';
-import type { GameState } from './state';
-import { initUI, type UIInitResult } from './ui';
+import { createAudioManager } from '../audio';
+import { t } from '../i18n';
+import { evaluateAchievements, recalcDerivedValues } from '../game';
+import type { GameState } from '../state';
+import { initUI, type UIInitResult } from './bootstrap';
 
-
-interface UITicker {
+export interface UITicker {
   render(state: GameState): void;
   stop(): void;
   refs: UIInitResult['refs'];


### PR DESCRIPTION
## Summary
- move the runtime bootstrap into `ui/start.ts` so it can consume the UI barrel without circular self-imports
- expose `startUI` and related types from `ui/index.ts` to keep external imports pointing at `./ui`

## Testing
- npm --prefix cannaclicker run build

------
https://chatgpt.com/codex/tasks/task_e_68d52ea63f60832db25da4f01bbe6796