### PR TITLE
Harden domain identifiers and UI references

### DIFF
--- a/cannaclicker/src/app/game.ts
+++ b/cannaclicker/src/app/game.ts
@@ -1,7 +1,8 @@
 import Decimal from 'break_infinity.js';
 import { itemById } from '../data/items';
+import type { ItemId } from '../data/items';
 import { achievements } from '../data/achievements';
-import { upgradeById, upgrades } from '../data/upgrades';
+import { upgradeById, upgrades, type UpgradeId } from '../data/upgrades';
 import { getItemCost, getTierMultiplier, getSoftcapMultiplier } from './shop';
 import type { GameState } from './state';
 import { sum, toDecimal } from './math';
@@ -61,9 +62,9 @@ export function recalcDerivedValues(state: GameState): void {
   state.temp.buildingBaseMultipliers = {};
   state.temp.buildingTierMultipliers = {};
 
-  const combinedCostMultipliers = new Map<string, Decimal>();
+  const combinedCostMultipliers = new Map<ItemId, Decimal>();
   const baseCostMultipliers = state.temp.buildingCostMultipliers ?? {};
-  for (const [key, value] of Object.entries(baseCostMultipliers)) {
+  for (const [key, value] of Object.entries(baseCostMultipliers) as [ItemId, Decimal][]) {
     const multiplier = value instanceof Decimal ? value : new Decimal(value);
     combinedCostMultipliers.set(key, multiplier);
   }
@@ -73,7 +74,7 @@ export function recalcDerivedValues(state: GameState): void {
     combinedCostMultipliers.set(target, current.mul(multiplier));
   }
 
-  const nextCostMultipliers: Record<string, Decimal> = {};
+  const nextCostMultipliers: Partial<Record<ItemId, Decimal>> = {};
   for (const [key, value] of combinedCostMultipliers.entries()) {
     nextCostMultipliers[key] = value;
   }
@@ -136,7 +137,7 @@ export function recalcDerivedValues(state: GameState): void {
 
 export function buyItem(
   state: GameState,
-  itemId: string,
+  itemId: ItemId,
   quantity = 1,
   source: 'manual' | 'auto' = 'manual',
 ): boolean {
@@ -170,7 +171,11 @@ export function buyItem(
   return true;
 }
 
-export function buyUpgrade(state: GameState, upgradeId: string, source: 'manual' | 'auto' = 'manual'): boolean {
+export function buyUpgrade(
+  state: GameState,
+  upgradeId: UpgradeId,
+  source: 'manual' | 'auto' = 'manual',
+): boolean {
   if (state.upgrades[upgradeId]) {
     return false;
   }
@@ -223,13 +228,13 @@ export function evaluateAchievements(state: GameState): void {
 
 function collectUpgradeEffects(state: GameState): {
   globalMultiplier: Decimal;
-  buildingMultipliers: Map<string, Decimal>;
-  buildingCostMultipliers: Map<string, Decimal>;
+  buildingMultipliers: Map<ItemId, Decimal>;
+  buildingCostMultipliers: Map<ItemId, Decimal>;
   clickMultiplier: Decimal;
   autoClickRate: number;
 } {
-  const buildingMultipliers = new Map<string, Decimal>();
-  const buildingCostMultipliers = new Map<string, Decimal>();
+  const buildingMultipliers = new Map<ItemId, Decimal>();
+  const buildingCostMultipliers = new Map<ItemId, Decimal>();
   let globalMultiplier = new Decimal(1);
   let clickMultiplier = new Decimal(1);
   let autoClickRate = 0;

--- a/cannaclicker/src/app/milestones.ts
+++ b/cannaclicker/src/app/milestones.ts
@@ -1,5 +1,10 @@
 import Decimal from "break_infinity.js";
-import { milestones, type MilestoneDefinition, type MilestoneRequirement } from "../data/milestones";
+import {
+  milestones,
+  type MilestoneDefinition,
+  type MilestoneId,
+  type MilestoneRequirement,
+} from "../data/milestones";
 import { items } from "../data/items";
 import type { GameState, KickstartState } from "./state";
 import { canUnlockItem } from "./shop";
@@ -42,7 +47,7 @@ export type MilestoneProgressDetail =
   | UnlockedAndAnyDetail;
 
 export interface MilestoneProgressSnapshot {
-  id: string;
+  id: MilestoneId;
   definition: MilestoneDefinition;
   achieved: boolean;
   progress: number;

--- a/cannaclicker/src/app/research.ts
+++ b/cannaclicker/src/app/research.ts
@@ -2,6 +2,7 @@ import Decimal from "break_infinity.js";
 import {
   RESEARCH,
   researchById,
+  type ResearchId,
   type ResearchNode,
   type ResearchUnlockCondition,
 } from "../data/research";
@@ -100,7 +101,7 @@ export function requirementsMet(state: GameState, node: ResearchNode): boolean {
   return true;
 }
 
-export function purchaseResearch(state: GameState, id: string): boolean {
+export function purchaseResearch(state: GameState, id: ResearchId): boolean {
   if (state.researchOwned.includes(id)) {
     return false;
   }
@@ -132,7 +133,7 @@ export function purchaseResearch(state: GameState, id: string): boolean {
   return true;
 }
 
-export function getResearchNode(id: string): ResearchNode | undefined {
+export function getResearchNode(id: ResearchId): ResearchNode | undefined {
   return researchById.get(id);
 }
 

--- a/cannaclicker/src/app/save/types.ts
+++ b/cannaclicker/src/app/save/types.ts
@@ -9,6 +9,12 @@ import type {
   PreferencesState,
   SeedGainEntry,
 } from '../state';
+import type { SeedSynergyId } from '../seeds';
+import type { AchievementId } from '../data/achievements';
+import type { ItemId } from '../data/items';
+import type { MilestoneId } from '../data/milestones';
+import type { ResearchId } from '../data/research';
+import type { UpgradeId } from '../data/upgrades';
 import type { LocaleKey } from '../i18n';
 import type { SettingsState } from '../settings';
 
@@ -29,7 +35,7 @@ export interface PersistedPrestigeState {
   lifetimeBuds?: string;
   lastResetAt?: number;
   version?: number;
-  milestones?: Record<string, boolean>;
+  milestones?: Partial<Record<MilestoneId, boolean>>;
   kickstart?: PersistedKickstartState | null;
 }
 
@@ -43,7 +49,7 @@ export interface PersistedMetaState {
   lastSeenAt?: number;
   lastBpsAtSave?: number;
   seedHistory?: PersistedSeedEntry[];
-  seedSynergyClaims?: Record<string, boolean>;
+  seedSynergyClaims?: Partial<Record<SeedSynergyId, boolean>>;
   lastInteractionAt?: number;
   seedPassiveIdleMs?: number;
   seedPassiveRollsDone?: number;
@@ -55,9 +61,9 @@ export interface PersistedStateV1Legacy {
   total: string;
   bps: string;
   bpc: string;
-  items?: Record<string, number>;
-  upgrades?: Record<string, boolean>;
-  achievements?: Record<string, boolean>;
+  items?: Partial<Record<ItemId, number>>;
+  upgrades?: Partial<Record<UpgradeId, boolean>>;
+  achievements?: Partial<Record<AchievementId, boolean>>;
   time?: number;
   locale?: LocaleKey;
   muted?: boolean;
@@ -69,13 +75,13 @@ export interface PersistedStateV2 {
   total: string;
   bps: string;
   bpc: string;
-  researchOwned: string[];
+  researchOwned: ResearchId[];
   prestige: PersistedPrestigeState;
-  abilities: Record<string, PersistedAbilityState>;
+  abilities: Record<AbilityId, PersistedAbilityState>;
   lastSeenAt: number;
-  items?: Record<string, number>;
-  upgrades?: Record<string, boolean>;
-  achievements?: Record<string, boolean>;
+  items?: Partial<Record<ItemId, number>>;
+  upgrades?: Partial<Record<UpgradeId, boolean>>;
+  achievements?: Partial<Record<AchievementId, boolean>>;
   locale?: LocaleKey;
   muted?: boolean;
 }
@@ -86,12 +92,12 @@ export interface PersistedStateV3 {
   total: string;
   bps: string;
   bpc: string;
-  items?: Record<string, number>;
-  upgrades?: Record<string, boolean>;
-  achievements?: Record<string, boolean>;
-  researchOwned?: string[];
+  items?: Partial<Record<ItemId, number>>;
+  upgrades?: Partial<Record<UpgradeId, boolean>>;
+  achievements?: Partial<Record<AchievementId, boolean>>;
+  researchOwned?: ResearchId[];
   prestige: PersistedPrestigeState;
-  abilities?: Record<string, PersistedAbilityState>;
+  abilities?: Record<AbilityId, PersistedAbilityState>;
   time?: number;
   lastSeenAt?: number;
   locale?: LocaleKey;
@@ -106,10 +112,10 @@ export interface PersistedStateV4 {
   total: string;
   bps: string;
   bpc: string;
-  items?: Record<string, number>;
-  upgrades?: Record<string, boolean>;
-  achievements?: Record<string, boolean>;
-  researchOwned: string[];
+  items?: Partial<Record<ItemId, number>>;
+  upgrades?: Partial<Record<UpgradeId, boolean>>;
+  achievements?: Partial<Record<AchievementId, boolean>>;
+  researchOwned: ResearchId[];
   prestige: PersistedPrestigeState;
   abilities: Record<AbilityId, PersistedAbilityState>;
   time?: number;
@@ -127,10 +133,10 @@ interface PersistedStateBase {
   total: string;
   bps: string;
   bpc: string;
-  items: Record<string, number>;
-  upgrades: Record<string, boolean>;
-  achievements: Record<string, boolean>;
-  researchOwned: string[];
+  items: Partial<Record<ItemId, number>>;
+  upgrades: Partial<Record<UpgradeId, boolean>>;
+  achievements: Partial<Record<AchievementId, boolean>>;
+  researchOwned: ResearchId[];
   prestige: PersistedPrestigeState;
   abilities: Record<AbilityId, PersistedAbilityState>;
   time: number;

--- a/cannaclicker/src/app/seeds.ts
+++ b/cannaclicker/src/app/seeds.ts
@@ -5,6 +5,13 @@ import type {
   SeedGainSource,
   SeedNotification,
 } from './state';
+import type { ItemId } from '../data/items';
+import type { ResearchId } from '../data/research';
+import type { UpgradeId } from '../data/upgrades';
+
+export const SEED_SYNERGY_IDS = ['closed_loop', 'hydro_link', 'climate_genetics'] as const;
+
+export type SeedSynergyId = (typeof SEED_SYNERGY_IDS)[number];
 
 const SEED_HISTORY_WINDOW_MS = 60 * 60 * 1000;
 const MAX_HISTORY_ENTRIES = 200;
@@ -12,13 +19,13 @@ const BASE_CLICK_SEED_CHANCE = 0.01;
 const MAX_CLICK_BONUS = 0.05;
 
 interface SeedSynergyDefinition {
-  id: string;
+  id: SeedSynergyId;
   seeds: number;
   labelKey: string;
   requirements: {
-    items?: Record<string, number>;
-    research?: string[];
-    upgrades?: string[];
+    items?: Partial<Record<ItemId, number>>;
+    research?: readonly ResearchId[];
+    upgrades?: readonly UpgradeId[];
   };
 }
 

--- a/cannaclicker/src/app/state.ts
+++ b/cannaclicker/src/app/state.ts
@@ -3,6 +3,14 @@ import { DEFAULT_LOCALE, type LocaleKey } from "./i18n";
 import { createDefaultSettings, type SettingsState } from "./settings";
 import { OFFLINE_CAP_MS } from "./balance";
 import type { MilestoneProgressSnapshot } from "./milestones";
+import type { AbilityId } from "../data/abilities";
+import type { AchievementId } from "../data/achievements";
+import type { ItemId } from "../data/items";
+import type { MilestoneId } from "../data/milestones";
+import type { ResearchId } from "../data/research";
+import type { UpgradeId } from "../data/upgrades";
+import type { SeedSynergyId } from "./seeds";
+export type { AbilityId } from "../data/abilities";
 
 export const SAVE_VERSION = 7 as const;
 
@@ -21,12 +29,10 @@ export interface SeedPassiveConfig {
 }
 
 export type SeedNotification =
-  | { type: "synergy"; id: string; seeds: number }
+  | { type: "synergy"; id: SeedSynergyId; seeds: number }
   | { type: "passive"; seeds: number };
 
 export type DecimalLike = Decimal | number | string | null | undefined;
-
-export type AbilityId = "overdrive" | "burst";
 
 export interface AbilityRuntimeState {
   active: boolean;
@@ -43,7 +49,7 @@ export interface PrestigeState {
   lifetimeBuds: Decimal;
   lastResetAt: number;
   version: number;
-  milestones: Record<string, boolean>;
+  milestones: Partial<Record<MilestoneId, boolean>>;
   kickstart: KickstartState | null;
 }
 
@@ -58,16 +64,16 @@ export interface TempState {
   totalBpsMult: Decimal;
   totalBpcMult: Decimal;
   costMultiplier: Decimal;
-  buildingCostMultipliers: Record<string, Decimal>;
+  buildingCostMultipliers: Partial<Record<ItemId, Decimal>>;
   autoClickRate: number;
   abilityPowerBonus: number;
   abilityDurationMult: number;
   offlineCapMs: number;
   offlineBuds: Decimal | null;
   offlineDuration: number;
-  buildingBaseMultipliers: Record<string, Decimal>;
-  buildingTierMultipliers: Record<string, Decimal>;
-  researchBuildingMultipliers: Record<string, Decimal>;
+  buildingBaseMultipliers: Partial<Record<ItemId, Decimal>>;
+  buildingTierMultipliers: Partial<Record<ItemId, Decimal>>;
+  researchBuildingMultipliers: Partial<Record<ItemId, Decimal>>;
   eventBpsMult: Decimal;
   eventBpcMult: Decimal;
   eventBoostEndsAt: number;
@@ -127,7 +133,7 @@ export interface MetaState {
   lastSeenAt: number;
   lastBpsAtSave: number;
   seedHistory: SeedGainEntry[];
-  seedSynergyClaims: Record<string, boolean>;
+  seedSynergyClaims: Partial<Record<SeedSynergyId, boolean>>;
   lastInteractionAt: number;
   seedPassiveIdleMs: number;
   seedPassiveRollsDone: number;
@@ -158,10 +164,10 @@ export interface SaveV5 {
   total: Decimal;
   bps: Decimal;
   bpc: Decimal;
-  items: Record<string, number>;
-  upgrades: Record<string, boolean>;
-  achievements: Record<string, boolean>;
-  researchOwned: string[];
+  items: Partial<Record<ItemId, number>>;
+  upgrades: Partial<Record<UpgradeId, boolean>>;
+  achievements: Partial<Record<AchievementId, boolean>>;
+  researchOwned: ResearchId[];
   prestige: PrestigeState;
   abilities: AbilityState;
   time: number;

--- a/cannaclicker/src/app/ui/components/controls.ts
+++ b/cannaclicker/src/app/ui/components/controls.ts
@@ -21,6 +21,9 @@ export function createActionButton(iconPath: string): ControlButtonRefs {
   button.type = "button";
   button.className =
     "inline-flex items-center gap-2 rounded-lg border border-white/10 bg-neutral-900/60 px-2.5 py-1.5 text-sm font-medium text-neutral-200 shadow-[0_10px_24px_rgba(9,11,19,0.45)] transition hover:border-emerald-400/40 hover:bg-neutral-800/70 focus-visible:ring-2 focus-visible:ring-emerald-300/70 focus-visible:ring-offset-0";
+  button.dataset.id = iconPath;
+  button.dataset.role = "control";
+  button.dataset.kind = "control";
 
   const icon = new Image();
   icon.src = iconPath;
@@ -49,10 +52,13 @@ export function createDangerButton(iconPath: string): ControlButtonRefs {
   return control;
 }
 
-export function createAbilityButton(id: string, state: GameState): AbilityButtonRefs {
+export function createAbilityButton(id: AbilityId, state: GameState): AbilityButtonRefs {
   const button = document.createElement("button");
   button.type = "button";
   button.className = "ability-btn";
+  button.dataset.id = id;
+  button.dataset.role = "ability";
+  button.dataset.kind = "ability";
 
   const header = document.createElement("div");
   header.className = "ability-header";
@@ -66,7 +72,7 @@ export function createAbilityButton(id: string, state: GameState): AbilityButton
   icon.loading = "lazy";
   icon.alt = "";
   icon.setAttribute("aria-hidden", "true");
-  icon.src = withBase(ABILITY_ICON_MAP[id as AbilityId] ?? "icons/ui/icon-leaf-click.png");
+  icon.src = withBase(ABILITY_ICON_MAP[id] ?? "icons/ui/icon-leaf-click.png");
   iconWrap.appendChild(icon);
 
   const meta = document.createElement("div");
@@ -74,7 +80,7 @@ export function createAbilityButton(id: string, state: GameState): AbilityButton
 
   const label = document.createElement("span");
   label.className = "ability-label";
-  const labelText = getAbilityLabel(state, id as AbilityId, state.locale);
+  const labelText = getAbilityLabel(state, id, state.locale);
   label.textContent = labelText;
 
   const status = document.createElement("span");
@@ -91,7 +97,7 @@ export function createAbilityButton(id: string, state: GameState): AbilityButton
   progress.appendChild(progressBar);
 
   button.append(header, progress);
-  button.title = formatAbilityTooltip(state, id as AbilityId, state.locale);
+  button.title = formatAbilityTooltip(state, id, state.locale);
   button.setAttribute("aria-label", labelText);
 
   return { container: button, icon, label, status, progressBar };

--- a/cannaclicker/src/app/ui/components/prestigePanel.ts
+++ b/cannaclicker/src/app/ui/components/prestigePanel.ts
@@ -1,4 +1,5 @@
 import { milestones } from "../../../data/milestones";
+import type { MilestoneId } from "../../../data/milestones";
 import type { MilestoneCardRefs, PrestigePanelRefs } from "../types";
 import { createMilestoneCard } from "./milestoneCard";
 
@@ -22,7 +23,7 @@ export function createPrestigePanel(): PrestigePanelRefs {
   milestoneList.className = "milestone-list";
   container.appendChild(milestoneList);
 
-  const milestoneRefs = new Map<string, MilestoneCardRefs>();
+  const milestoneRefs = new Map<MilestoneId, MilestoneCardRefs>();
   milestones.forEach((definition) => {
     const card = createMilestoneCard();
     milestoneRefs.set(definition.id, card);
@@ -36,6 +37,9 @@ export function createPrestigePanel(): PrestigePanelRefs {
   const actionButton = document.createElement("button");
   actionButton.type = "button";
   actionButton.className = "prestige-panel__action";
+  actionButton.dataset.id = "prestige";
+  actionButton.dataset.role = "prestige-action";
+  actionButton.dataset.kind = "prestige";
   container.appendChild(actionButton);
 
   return {

--- a/cannaclicker/src/app/ui/mountPanels.ts
+++ b/cannaclicker/src/app/ui/mountPanels.ts
@@ -1,6 +1,7 @@
 import { listAbilities } from "../abilities";
 import { withBase } from "../paths";
 import type { GameState } from "../state";
+import type { AbilityId } from "../../data/abilities";
 import { createAbilityButton } from "./components/controls";
 import { createPrestigeModal } from "./components/prestigeModal";
 import { createStatBlock } from "./components/stats";
@@ -125,7 +126,7 @@ export function mountPanels(args: MountPanelsArgs): MountPanelsResult {
   abilityGrid.className = "ability-grid";
   abilitySection.appendChild(abilityGrid);
 
-  const abilityRefs = new Map<string, AbilityButtonRefs>();
+  const abilityRefs = new Map<AbilityId, AbilityButtonRefs>();
   for (const ability of listAbilities()) {
     const abilityButton = createAbilityButton(ability.id, state);
     abilityRefs.set(ability.id, abilityButton);

--- a/cannaclicker/src/app/ui/mountPanels/panels.ts
+++ b/cannaclicker/src/app/ui/mountPanels/panels.ts
@@ -1,5 +1,6 @@
 import { listAbilities } from "../../abilities";
 import type { GameState } from "../../state";
+import type { AbilityId } from "../../../data/abilities";
 import { createAbilityButton } from "../components/controls";
 import { createStatBlock } from "../components/stats";
 import { createSidePanel } from "../panels/sidePanel";
@@ -86,7 +87,7 @@ export function mountPrimaryPanels(args: MountPanelsArgs): MountPanelsResult {
   abilityGrid.className = "ability-grid";
   abilitySection.appendChild(abilityGrid);
 
-  const abilityList = new Map<string, AbilityButtonRefs>();
+  const abilityList = new Map<AbilityId, AbilityButtonRefs>();
   for (const ability of listAbilities()) {
     const abilityButton = createAbilityButton(ability.id, state);
     abilityList.set(ability.id, abilityButton);

--- a/cannaclicker/src/app/ui/panels/sidePanel.ts
+++ b/cannaclicker/src/app/ui/panels/sidePanel.ts
@@ -1,8 +1,19 @@
 import { achievements } from "../../../data/achievements";
+import type { AchievementId } from "../../../data/achievements";
+import type { ItemId } from "../../../data/items";
+import type { ResearchId } from "../../../data/research";
+import type { UpgradeId } from "../../../data/upgrades";
 import type { ResearchFilter } from "../../research";
 import { createAchievementCard } from "../components/achievementCard";
 import { createPrestigePanel } from "../components/prestigePanel";
-import type { AchievementCardRefs, SidePanelRefs, SidePanelTab } from "../types";
+import type {
+  AchievementCardRefs,
+  ResearchCardRefs,
+  ShopCardRefs,
+  SidePanelRefs,
+  SidePanelTab,
+  UpgradeCardRefs,
+} from "../types";
 
 export function createSidePanel(
   activeSidePanelTab: SidePanelTab,
@@ -19,7 +30,9 @@ export function createSidePanel(
   (['shop', 'upgrades', 'research', 'prestige', 'achievements'] as SidePanelTab[]).forEach((tab) => {
     const button = document.createElement("button");
     button.type = "button";
-    button.dataset.tab = tab;
+    button.dataset.id = tab;
+    button.dataset.role = "side-panel-tab";
+    button.dataset.kind = "side-panel";
     button.className = "tab-button";
     button.setAttribute("aria-pressed", "false");
     button.setAttribute("role", "tab");
@@ -51,11 +64,13 @@ export function createSidePanel(
   researchControls.className = "research-controls";
   const filterWrap = document.createElement("div");
   filterWrap.className = "research-filters";
-  const researchFilters = new Map<string, HTMLButtonElement>();
+  const researchFilters = new Map<ResearchFilter, HTMLButtonElement>();
   (['all', 'available', 'owned'] as ResearchFilter[]).forEach((key) => {
     const button = document.createElement("button");
     button.type = "button";
-    button.dataset.filter = key;
+    button.dataset.id = key;
+    button.dataset.role = "research-filter";
+    button.dataset.kind = "research";
     button.className = "filter-pill";
     filterWrap.appendChild(button);
     researchFilters.set(key, button);
@@ -79,7 +94,7 @@ export function createSidePanel(
   achievementsView.appendChild(achievementsList);
   viewsContainer.appendChild(achievementsView);
 
-  const achievementRefs = new Map<string, AchievementCardRefs>();
+  const achievementRefs = new Map<AchievementId, AchievementCardRefs>();
   achievements.forEach((definition) => {
     const card = createAchievementCard(definition);
     achievementRefs.set(definition.id, card);
@@ -110,17 +125,17 @@ export function createSidePanel(
     views,
     shop: {
       list: shopList,
-      entries: new Map(),
+      entries: new Map<ItemId, ShopCardRefs>(),
     },
     upgrades: {
       list: upgradeList,
-      entries: new Map(),
+      entries: new Map<UpgradeId, UpgradeCardRefs>(),
     },
     research: {
       container: researchView,
       filters: researchFilters,
       list: researchList,
-      entries: new Map(),
+      entries: new Map<ResearchId, ResearchCardRefs>(),
       emptyState: researchEmpty,
     },
     prestige: prestigePanel,

--- a/cannaclicker/src/app/ui/types/abilities.ts
+++ b/cannaclicker/src/app/ui/types/abilities.ts
@@ -1,3 +1,5 @@
+import type { AbilityId } from "../../../data/abilities";
+
 export interface AbilityButtonRefs {
   container: HTMLButtonElement;
   icon: HTMLImageElement;
@@ -8,5 +10,5 @@ export interface AbilityButtonRefs {
 
 export interface UIAbilityPanelRefs {
   abilityTitle: HTMLElement;
-  abilityList: Map<string, AbilityButtonRefs>;
+  abilityList: Map<AbilityId, AbilityButtonRefs>;
 }

--- a/cannaclicker/src/app/ui/types/prestige.ts
+++ b/cannaclicker/src/app/ui/types/prestige.ts
@@ -9,6 +9,8 @@ export interface MilestoneCardRefs {
   progressLabel: HTMLElement;
 }
 
+import type { MilestoneId } from "../../../data/milestones";
+
 export interface PrestigePanelRefs {
   container: HTMLElement;
   description: HTMLElement;
@@ -19,7 +21,7 @@ export interface PrestigePanelRefs {
   activeKickstartLabel: HTMLElement;
   activeKickstartValue: HTMLElement;
   milestoneList: HTMLElement;
-  milestones: Map<string, MilestoneCardRefs>;
+  milestones: Map<MilestoneId, MilestoneCardRefs>;
   requirement: HTMLElement;
   actionButton: HTMLButtonElement;
 }

--- a/cannaclicker/src/app/ui/types/sidePanel.ts
+++ b/cannaclicker/src/app/ui/types/sidePanel.ts
@@ -1,7 +1,12 @@
+import type { AchievementId } from "../../../data/achievements";
+import type { ItemId } from "../../../data/items";
+import type { ResearchId } from "../../../data/research";
+import type { UpgradeId } from "../../../data/upgrades";
+import type { ResearchFilter } from "../../research";
 import type { PrestigePanelRefs } from "./prestige";
 
 export interface ResearchCardRefs {
-  id: string;
+  id: ResearchId;
   container: HTMLElement;
   icon: HTMLImageElement | null;
   path: HTMLElement;
@@ -64,23 +69,23 @@ export interface SidePanelRefs {
   views: Record<SidePanelTab, HTMLElement>;
   shop: {
     list: HTMLElement;
-    entries: Map<string, ShopCardRefs>;
+    entries: Map<ItemId, ShopCardRefs>;
   };
   upgrades: {
     list: HTMLElement;
-    entries: Map<string, UpgradeCardRefs>;
+    entries: Map<UpgradeId, UpgradeCardRefs>;
   };
   research: {
     container: HTMLElement;
-    filters: Map<string, HTMLButtonElement>;
+    filters: Map<ResearchFilter, HTMLButtonElement>;
     list: HTMLElement;
-    entries: Map<string, ResearchCardRefs>;
+    entries: Map<ResearchId, ResearchCardRefs>;
     emptyState: HTMLElement;
   };
   prestige: PrestigePanelRefs;
   achievements: {
     list: HTMLElement;
-    entries: Map<string, AchievementCardRefs>;
+    entries: Map<AchievementId, AchievementCardRefs>;
   };
 }
 

--- a/cannaclicker/src/app/ui/updaters/abilities.ts
+++ b/cannaclicker/src/app/ui/updaters/abilities.ts
@@ -5,24 +5,24 @@ import {
   getAbilityLabel,
   getAbilityProgress,
 } from "../../abilities";
-import type { AbilityId, GameState } from "../../state";
+import type { GameState } from "../../state";
 import type { UIRefs } from "../types";
 
 export function updateAbilities(state: GameState, refs: UIRefs): void {
   const now = Date.now();
   refs.abilityList.forEach((abilityRefs, abilityId) => {
-    const ability = getAbilityDefinition(abilityId as AbilityId);
-    const runtime = state.abilities[abilityId as AbilityId];
+    const ability = getAbilityDefinition(abilityId);
+    const runtime = state.abilities[abilityId];
     if (!ability || !runtime) {
       return;
     }
 
-    const labelText = getAbilityLabel(state, abilityId as AbilityId, state.locale);
+    const labelText = getAbilityLabel(state, abilityId, state.locale);
     abilityRefs.label.textContent = labelText;
-    abilityRefs.container.title = formatAbilityTooltip(state, abilityId as AbilityId, state.locale);
+    abilityRefs.container.title = formatAbilityTooltip(state, abilityId, state.locale);
     abilityRefs.container.setAttribute("aria-label", labelText);
 
-    const progress = getAbilityProgress(state, abilityId as AbilityId, now);
+    const progress = getAbilityProgress(state, abilityId, now);
     const button = abilityRefs.container;
     const status = abilityRefs.status;
     const progressBar = abilityRefs.progressBar;

--- a/cannaclicker/src/app/ui/updaters/prestigePanel.ts
+++ b/cannaclicker/src/app/ui/updaters/prestigePanel.ts
@@ -3,6 +3,8 @@ import { formatDecimal } from "../../math";
 import type { GameState } from "../../state";
 import { getPrestigePreview } from "../../prestige";
 import { milestones } from "../../../data/milestones";
+import type { MilestoneId } from "../../../data/milestones";
+import type { MilestoneProgressSnapshot } from "../../milestones";
 import type { UIRefs, MilestoneCardRefs } from "../types";
 import {
   formatActiveKickstartSummary,
@@ -47,10 +49,15 @@ export function updatePrestigePanel(state: GameState, refs: UIRefs): void {
   );
 }
 
-function updateMilestoneCards(state: GameState, cards: Map<string, MilestoneCardRefs>): void {
+function updateMilestoneCards(
+  state: GameState,
+  cards: Map<MilestoneId, MilestoneCardRefs>,
+): void {
   const locale = state.locale;
   const progressList = state.temp.milestoneProgress ?? [];
-  const progressMap = new Map(progressList.map((snapshot) => [snapshot.id, snapshot]));
+  const progressMap = new Map<MilestoneId, MilestoneProgressSnapshot>(
+    progressList.map((snapshot) => [snapshot.id, snapshot]),
+  );
 
   milestones.forEach((definition) => {
     const card = cards.get(definition.id);

--- a/cannaclicker/src/app/ui/updaters/research/list.ts
+++ b/cannaclicker/src/app/ui/updaters/research/list.ts
@@ -5,6 +5,7 @@ import {
   type ResearchFilter,
   type ResearchViewModel,
 } from "../../../research";
+import type { ResearchId } from "../../../../data/research";
 import type { UIRefs } from "../../types";
 import type { ResearchCardRefs } from "../../types";
 import { renderResearchCard } from "./renderCard";
@@ -31,7 +32,7 @@ export function renderResearchList(
 
   removeEmptyState(list, researchRefs.emptyState);
 
-  const visible = new Set<string>();
+  const visible = new Set<ResearchId>();
 
   data.forEach((entry, index) => {
     const card = ensureResearchCard(state, researchRefs.entries, entry, onPurchase);
@@ -63,7 +64,7 @@ function removeEmptyState(list: Element, emptyState: HTMLElement): void {
 
 function ensureResearchCard(
   state: GameState,
-  entries: Map<string, ResearchCardRefs>,
+  entries: Map<ResearchId, ResearchCardRefs>,
   entry: ResearchViewModel,
   onPurchase: () => void,
 ): ResearchCardRefs {
@@ -85,8 +86,8 @@ function syncListOrder(list: Element, card: HTMLElement, targetIndex: number): v
 
 function removeHiddenCards(
   list: Element,
-  entries: Map<string, ResearchCardRefs>,
-  visible: Set<string>,
+  entries: Map<ResearchId, ResearchCardRefs>,
+  visible: Set<ResearchId>,
 ): void {
   entries.forEach((card, id) => {
     if (!visible.has(id) && card.container.parentElement === list) {

--- a/cannaclicker/src/app/ui/updaters/research/makeCard.ts
+++ b/cannaclicker/src/app/ui/updaters/research/makeCard.ts
@@ -1,7 +1,8 @@
 import { getResearchNode } from "../../../research";
+import type { ResearchId } from "../../../../data/research";
 import type { ResearchCardRefs } from "../../types";
 
-export function createResearchCard(id: string): ResearchCardRefs {
+export function createResearchCard(id: ResearchId): ResearchCardRefs {
   const node = getResearchNode(id);
   if (!node) {
     throw new Error(`Unknown research node ${id}`);
@@ -9,7 +10,9 @@ export function createResearchCard(id: string): ResearchCardRefs {
 
   const container = document.createElement("article");
   container.className = "research-card";
-  container.dataset.researchId = id;
+  container.dataset.id = id;
+  container.dataset.kind = "research";
+  container.dataset.role = "card";
 
   const header = document.createElement("div");
   header.className = "research-header";
@@ -67,7 +70,9 @@ export function createResearchCard(id: string): ResearchCardRefs {
   const button = document.createElement("button");
   button.type = "button";
   button.className = "research-btn";
-  button.dataset.researchId = id;
+  button.dataset.id = id;
+  button.dataset.role = "research-buy";
+  button.dataset.kind = "research";
   actions.appendChild(button);
 
   return {

--- a/cannaclicker/src/app/ui/updaters/shop/list.ts
+++ b/cannaclicker/src/app/ui/updaters/shop/list.ts
@@ -1,5 +1,6 @@
 import type { GameState } from "../../../state";
 import { getShopEntries, type ShopEntry } from "../../../shop";
+import type { ItemId } from "../../../../data/items";
 import type { ShopCardRefs, UIRefs } from "../../types";
 import { renderShopCard } from "./renderCard";
 import { createShopCard } from "./makeCard";
@@ -23,7 +24,7 @@ export function renderShopList(
 
 function ensureShopCard(
   state: GameState,
-  entries: Map<string, ShopCardRefs>,
+  entries: Map<ItemId, ShopCardRefs>,
   entry: ShopEntry,
   options: ShopUpdateOptions,
 ): ShopCardRefs {

--- a/cannaclicker/src/app/ui/updaters/shop/makeCard.ts
+++ b/cannaclicker/src/app/ui/updaters/shop/makeCard.ts
@@ -82,12 +82,18 @@ export function createShopCard(definition: ItemDefinition, state: GameState): Sh
   buyButton.type = "button";
   buyButton.className = "buy-btn h-10 flex-1";
   buyButton.textContent = t(state.locale, "actions.buy");
+  buyButton.dataset.id = definition.id;
+  buyButton.dataset.role = "shop-buy";
+  buyButton.dataset.kind = "shop";
 
   const maxButton = document.createElement("button");
   maxButton.type = "button";
   maxButton.className =
     "h-10 shrink-0 rounded-lg border border-white/10 px-4 text-sm font-semibold text-neutral-200 transition hover:border-emerald-400 focus-visible:ring-2 focus-visible:ring-emerald-300";
   maxButton.textContent = t(state.locale, "actions.max");
+  maxButton.dataset.id = definition.id;
+  maxButton.dataset.role = "shop-max";
+  maxButton.dataset.kind = "shop";
 
   actions.append(buyButton, maxButton);
   info.appendChild(actions);

--- a/cannaclicker/src/app/ui/updaters/strings.ts
+++ b/cannaclicker/src/app/ui/updaters/strings.ts
@@ -1,4 +1,4 @@
-import type { AbilityId, GameState } from "../../state";
+import type { GameState } from "../../state";
 import { asset } from "../../assets";
 import { t, type LocaleKey } from "../../i18n";
 import { formatAbilityTooltip, getAbilityLabel } from "../../abilities";
@@ -73,9 +73,9 @@ export function updateStrings(state: GameState, refs: UIRefs): void {
 
   refs.abilityTitle.textContent = t(state.locale, "abilities.title");
   refs.abilityList.forEach((abilityRefs, abilityId) => {
-    const labelText = getAbilityLabel(state, abilityId as AbilityId, state.locale);
+    const labelText = getAbilityLabel(state, abilityId, state.locale);
     abilityRefs.label.textContent = labelText;
-    abilityRefs.container.title = formatAbilityTooltip(state, abilityId as AbilityId, state.locale);
+    abilityRefs.container.title = formatAbilityTooltip(state, abilityId, state.locale);
     abilityRefs.container.setAttribute("aria-label", labelText);
   });
 

--- a/cannaclicker/src/app/ui/updaters/upgrades/list.ts
+++ b/cannaclicker/src/app/ui/updaters/upgrades/list.ts
@@ -1,5 +1,6 @@
 import type { GameState } from "../../../state";
 import { getUpgradeEntries, type UpgradeEntry as UpgradeViewEntry } from "../../../upgrades";
+import type { UpgradeId } from "../../../../data/upgrades";
 import type { UIRefs, UpgradeCardRefs } from "../../types";
 import { createUpgradeCard } from "./makeCard";
 import { renderUpgradeCard } from "./renderCard";
@@ -23,7 +24,7 @@ export function renderUpgradeList(
 
 function ensureUpgradeCard(
   state: GameState,
-  entries: Map<string, UpgradeCardRefs>,
+  entries: Map<UpgradeId, UpgradeCardRefs>,
   entry: UpgradeViewEntry,
   options: UpgradeUpdateOptions,
 ): UpgradeCardRefs {

--- a/cannaclicker/src/app/ui/updaters/upgrades/makeCard.ts
+++ b/cannaclicker/src/app/ui/updaters/upgrades/makeCard.ts
@@ -68,6 +68,9 @@ export function createUpgradeCard(
   buyButton.type = "button";
   buyButton.className = "upgrade-card__button";
   buyButton.textContent = t(state.locale, "upgrades.action.buy");
+  buyButton.dataset.id = definition.id;
+  buyButton.dataset.role = "upgrade-buy";
+  buyButton.dataset.kind = "upgrade";
 
   footer.append(costWrap, buyButton);
 

--- a/cannaclicker/src/app/upgrades.ts
+++ b/cannaclicker/src/app/upgrades.ts
@@ -3,9 +3,11 @@ import {
   upgradeById,
   upgrades,
   type UpgradeDefinition,
+  type UpgradeId,
   type UpgradeRequirement,
 } from "../data/upgrades";
 import { itemById } from "../data/items";
+import type { ItemId } from "../data/items";
 import { formatDecimal } from "./math";
 import type { GameState } from "./state";
 import type { LocaleKey } from "./i18n";
@@ -13,7 +15,7 @@ import type { LocaleKey } from "./i18n";
 export type UpgradeRequirementDetail =
   | {
       kind: "itemsOwned";
-      id: string;
+      id: ItemId;
       required: number;
       current: number;
       remaining: number;
@@ -26,7 +28,7 @@ export type UpgradeRequirementDetail =
     }
   | {
       kind: "upgradesOwned";
-      id: string;
+      id: UpgradeId;
       owned: boolean;
     };
 
@@ -41,7 +43,7 @@ export interface UpgradeEntry {
   primaryLock: UpgradeRequirementDetail | null;
 }
 
-export function getUpgradeDefinition(id: string): UpgradeDefinition | undefined {
+export function getUpgradeDefinition(id: UpgradeId): UpgradeDefinition | undefined {
   return upgradeById.get(id);
 }
 
@@ -85,7 +87,7 @@ function describeRequirement(
   const details: UpgradeRequirementDetail[] = [];
 
   if (requirement.itemsOwned) {
-    for (const [itemId, required] of Object.entries(requirement.itemsOwned)) {
+    for (const [itemId, required] of Object.entries(requirement.itemsOwned) as [ItemId, number][]) {
       const current = state.items[itemId] ?? 0;
       const remaining = Math.max(0, required - current);
       details.push({

--- a/cannaclicker/src/data/abilities.ts
+++ b/cannaclicker/src/data/abilities.ts
@@ -1,16 +1,4 @@
-export type AbilityId = "overdrive" | "burst";
-
-export interface Ability {
-  id: AbilityId;
-  nameKey: string;
-  descriptionKey: string;
-  durationSec: number;
-  cooldownSec: number;
-  baseMultiplier: number;
-  appliesTo: "bps" | "bpc";
-}
-
-export const ABILITIES: Ability[] = [
+const ABILITY_DATA = [
   {
     id: "overdrive",
     nameKey: "abilities.overdrive.name",
@@ -30,3 +18,11 @@ export const ABILITIES: Ability[] = [
     appliesTo: "bpc",
   },
 ];
+
+type RawAbility = (typeof ABILITY_DATA)[number];
+
+export type AbilityId = RawAbility["id"];
+
+export type Ability = RawAbility & { id: AbilityId };
+
+export const ABILITIES: readonly Ability[] = ABILITY_DATA;

--- a/cannaclicker/src/data/achievements.ts
+++ b/cannaclicker/src/data/achievements.ts
@@ -1,22 +1,8 @@
-﻿import { asset } from "../app/assets";
+import { asset } from "../app/assets";
 
-import type { LocaleKey } from '../app/i18n';
+import type { ItemId } from "./items";
 
-export interface AchievementRequirement {
-  totalBuds?: number;
-  itemsOwned?: Record<string, number>;
-}
-
-export interface AchievementDefinition {
-  id: string;
-  name: Record<LocaleKey, string>;
-  description: Record<LocaleKey, string>;
-  overlayIcon: string;
-  requirement: AchievementRequirement;
-  rewardMultiplier?: number;
-}
-
-export const achievements: AchievementDefinition[] = [
+const ACHIEVEMENT_DATA = [
   {
     id: 'seedling_10',
     overlayIcon: asset('achievements/badge-overlay-leaf.png'),
@@ -67,6 +53,23 @@ export const achievements: AchievementDefinition[] = [
   },
 ];
 
-export const achievementById = new Map(achievements.map((entry) => [entry.id, entry] as const));
+type RawAchievementDefinition = (typeof ACHIEVEMENT_DATA)[number];
+
+export type AchievementId = RawAchievementDefinition["id"];
+
+export interface AchievementRequirement {
+  totalBuds?: number;
+  itemsOwned?: Partial<Record<ItemId, number>>;
+}
+
+export type AchievementDefinition = RawAchievementDefinition & {
+  requirement: AchievementRequirement;
+};
+
+export const achievements: readonly AchievementDefinition[] = ACHIEVEMENT_DATA;
+
+export const achievementById = new Map<AchievementId, AchievementDefinition>(
+  achievements.map((entry) => [entry.id, entry]),
+);
 
 

--- a/cannaclicker/src/data/items.ts
+++ b/cannaclicker/src/data/items.ts
@@ -1,29 +1,6 @@
-﻿import { asset } from "../app/assets";
+import { asset } from "../app/assets";
 
-export interface UnlockCondition {
-  totalBuds?: number;
-  itemsOwned?: Record<string, number>;
-}
-
-export interface ItemDefinition {
-  id: string;
-  name: Record<'de' | 'en', string>;
-  description: Record<'de' | 'en', string>;
-  tier: number;
-  baseCost: number;
-  costFactor: number;
-  bps: number;
-  icon: string;
-  tierSize?: number;
-  tierBonusMult?: number;
-  softcapTier?: number;
-  softcapMult?: number;
-  softcapCopies?: number;
-  softcapPenalty?: number;
-  unlock?: UnlockCondition;
-}
-
-export const items: ItemDefinition[] = [
+const ITEM_DATA = [
   {
     id: 'seedling',
     name: {
@@ -287,5 +264,18 @@ export const items: ItemDefinition[] = [
   },
 ];
 
-export const itemById = new Map(items.map((item) => [item.id, item] as const));
+type RawItemDefinition = (typeof ITEM_DATA)[number];
+
+export type ItemId = RawItemDefinition["id"];
+
+export interface UnlockCondition {
+  totalBuds?: number;
+  itemsOwned?: Partial<Record<ItemId, number>>;
+}
+
+export type ItemDefinition = RawItemDefinition & { unlock?: UnlockCondition };
+
+export const items: readonly ItemDefinition[] = ITEM_DATA;
+
+export const itemById = new Map<ItemId, ItemDefinition>(items.map((item) => [item.id, item]));
 

--- a/cannaclicker/src/data/milestones.ts
+++ b/cannaclicker/src/data/milestones.ts
@@ -13,7 +13,7 @@ export interface MilestoneBonus {
   value: number;
 }
 
-export interface MilestoneDefinition {
+interface MilestoneDefinitionSpec {
   id: string;
   order: number;
   name: Record<LocaleKey, string>;
@@ -24,7 +24,7 @@ export interface MilestoneDefinition {
   kickstartLevel?: number;
 }
 
-export const milestones: MilestoneDefinition[] = [
+const MILESTONE_DATA = [
   {
     id: "m1",
     order: 1,
@@ -211,6 +211,16 @@ export const milestones: MilestoneDefinition[] = [
     bonuses: [{ type: "bps", value: 0.15 }],
     kickstartLevel: 6,
   },
-];
+] as const satisfies readonly MilestoneDefinitionSpec[];
 
-export const milestoneById = new Map(milestones.map((milestone) => [milestone.id, milestone]));
+type RawMilestoneDefinition = (typeof MILESTONE_DATA)[number];
+
+export type MilestoneId = RawMilestoneDefinition["id"];
+
+export type MilestoneDefinition = RawMilestoneDefinition & { id: MilestoneId };
+
+export const milestones: readonly MilestoneDefinition[] = MILESTONE_DATA;
+
+export const milestoneById = new Map<MilestoneId, MilestoneDefinition>(
+  milestones.map((milestone) => [milestone.id, milestone]),
+);

--- a/cannaclicker/src/data/upgrades.ts
+++ b/cannaclicker/src/data/upgrades.ts
@@ -1,31 +1,45 @@
 import { asset } from "../app/assets";
 import type { LocaleKey } from "../app/i18n";
 import { items, itemById } from "./items";
+import type { ItemId } from "./items";
 
 export type UpgradeCategory = "building" | "synergy" | "utility";
 
 export type UpgradeEffect =
   | { type: "globalMultiplier"; value: number }
   | { type: "clickMultiplier"; value: number }
-  | { type: "buildingMultiplier"; targets: string[]; value: number }
-  | { type: "buildingCostMultiplier"; targets: string[]; value: number }
+  | { type: "buildingMultiplier"; targets: readonly ItemId[]; value: number }
+  | { type: "buildingCostMultiplier"; targets: readonly ItemId[]; value: number }
   | { type: "autoClick"; value: number };
+
+type BuildingUpgradeStage = 1 | 2 | 3 | 4;
+type TrimmerUpgradeStage = 1 | 2 | 3 | 4 | 5 | 6;
+
+type BuildingUpgradeId = `${ItemId}_boost_${BuildingUpgradeStage}` | "grow_light_lenses";
+
+export type UpgradeId =
+  | BuildingUpgradeId
+  | `trimmer_auto_${TrimmerUpgradeStage}`
+  | "rich_soil"
+  | "precision_trim"
+  | "synergy_closed_loop"
+  | "synergy_precision_irrigation";
 
 export interface UpgradeRequirement {
   totalBuds?: number;
-  itemsOwned?: Record<string, number>;
-  upgradesOwned?: string[];
+  itemsOwned?: Partial<Record<ItemId, number>>;
+  upgradesOwned?: readonly UpgradeId[];
 }
 
 export interface UpgradeDefinition {
-  id: string;
+  id: UpgradeId;
   category: UpgradeCategory;
-  targetIds?: string[];
+  targetIds?: readonly ItemId[];
   name: Record<LocaleKey, string>;
   description: Record<LocaleKey, string>;
   cost: number;
   icon: string;
-  effects: UpgradeEffect[];
+  effects: readonly UpgradeEffect[];
   requirement?: UpgradeRequirement;
   order: number;
 }
@@ -33,7 +47,7 @@ export interface UpgradeDefinition {
 const BUILDING_THRESHOLDS = [10, 25, 50, 100] as const;
 const BUILDING_COST_FACTORS = [8, 25, 80, 250] as const;
 
-const BUILDING_ICON_OVERRIDES: Partial<Record<string, string>> = {
+const BUILDING_ICON_OVERRIDES: Partial<Record<ItemId, string>> = {
   seedling: asset("icons/upgrades/upgrade-seedling.png"),
   planter: asset("icons/upgrades/upgrade-planter.png"),
   grow_tent: asset("icons/upgrades/upgrade-tent.png"),
@@ -41,11 +55,11 @@ const BUILDING_ICON_OVERRIDES: Partial<Record<string, string>> = {
   cultivator: asset("icons/upgrades/upgrade-cultivator.png"),
 };
 
-const BUILDING_STAGE_ID_OVERRIDES: Partial<Record<string, (string | undefined)[]>> = {
+const BUILDING_STAGE_ID_OVERRIDES: Partial<Record<ItemId, readonly (UpgradeId | undefined)[]>> = {
   grow_light: ["grow_light_lenses"],
 };
 
-const BUILDING_STAGE_TITLE_OVERRIDES: Partial<Record<string, Record<number, Record<LocaleKey, string>>>> = {
+const BUILDING_STAGE_TITLE_OVERRIDES: Partial<Record<ItemId, Record<number, Record<LocaleKey, string>>>> = {
   grow_light: {
     1: {
       de: "Prismatische Linsen",
@@ -54,7 +68,7 @@ const BUILDING_STAGE_TITLE_OVERRIDES: Partial<Record<string, Record<number, Reco
   },
 };
 
-const BUILDING_STAGE_DESCRIPTION_OVERRIDES: Partial<Record<string, Record<number, Record<LocaleKey, string>>>> = {
+const BUILDING_STAGE_DESCRIPTION_OVERRIDES: Partial<Record<ItemId, Record<number, Record<LocaleKey, string>>>> = {
   grow_light: {
     1: {
       de: "LED-Lichter produzieren 2× Buds.",
@@ -78,20 +92,24 @@ function formatBoostDescription(base: Record<LocaleKey, string>): Record<LocaleK
   } satisfies Record<LocaleKey, string>;
 }
 
-function resolveBuildingIcon(itemId: string, fallback: string): string {
+function resolveBuildingIcon(itemId: ItemId, fallback: string): string {
   return BUILDING_ICON_OVERRIDES[itemId] ?? fallback;
 }
 
-function resolveStageId(itemId: string, stageIndex: number): string {
+function resolveStageId(itemId: ItemId, stageIndex: number): UpgradeId {
   const overrides = BUILDING_STAGE_ID_OVERRIDES[itemId];
   const override = overrides?.[stageIndex];
   if (override) {
     return override;
   }
-  return `${itemId}_boost_${stageIndex + 1}`;
+  return `${itemId}_boost_${stageIndex + 1}` as UpgradeId;
 }
 
-function resolveStageName(itemId: string, stageIndex: number, baseName: Record<LocaleKey, string>): Record<LocaleKey, string> {
+function resolveStageName(
+  itemId: ItemId,
+  stageIndex: number,
+  baseName: Record<LocaleKey, string>,
+): Record<LocaleKey, string> {
   const stageNumber = stageIndex + 1;
   const overrides = BUILDING_STAGE_TITLE_OVERRIDES[itemId]?.[stageNumber];
   if (overrides) {
@@ -101,7 +119,7 @@ function resolveStageName(itemId: string, stageIndex: number, baseName: Record<L
 }
 
 function resolveStageDescription(
-  itemId: string,
+  itemId: ItemId,
   stageIndex: number,
   baseDescription: Record<LocaleKey, string>,
 ): Record<LocaleKey, string> {
@@ -150,7 +168,7 @@ function createBuildingUpgrades(): UpgradeDefinition[] {
   return entries;
 }
 
-function getBaseCost(itemId: string): number {
+function getBaseCost(itemId: ItemId): number {
   const definition = itemById.get(itemId);
   return definition?.baseCost ?? 1;
 }
@@ -164,7 +182,7 @@ function createSynergyUpgrades(): UpgradeDefinition[] {
     {
       id: "synergy_closed_loop",
       category: "synergy",
-      targetIds: ["grow_tent", "grow_light", "co2_tank"],
+      targetIds: ["grow_tent", "grow_light", "co2_tank"] as const,
       name: {
         de: "Geschlossener Kreislauf",
         en: "Closed Loop Cycle",
@@ -176,7 +194,11 @@ function createSynergyUpgrades(): UpgradeDefinition[] {
       cost: Math.round(co2Base * 120),
       icon: asset("icons/upgrades/upgrade-global-bps.png"),
       effects: [
-        { type: "buildingMultiplier", targets: ["grow_tent", "grow_light", "co2_tank"], value: 1.2 },
+        {
+          type: "buildingMultiplier",
+          targets: ["grow_tent", "grow_light", "co2_tank"] as const,
+          value: 1.2,
+        },
       ],
       requirement: {
         itemsOwned: { grow_tent: 40, grow_light: 40, co2_tank: 15 },
@@ -187,7 +209,7 @@ function createSynergyUpgrades(): UpgradeDefinition[] {
     {
       id: "synergy_precision_irrigation",
       category: "synergy",
-      targetIds: ["climate_controller", "hydroponic_rack", "irrigation_system"],
+      targetIds: ["climate_controller", "hydroponic_rack", "irrigation_system"] as const,
       name: {
         de: "Feintuning",
         en: "Fine Tuning",
@@ -201,7 +223,7 @@ function createSynergyUpgrades(): UpgradeDefinition[] {
       effects: [
         {
           type: "buildingCostMultiplier",
-          targets: ["climate_controller", "hydroponic_rack", "irrigation_system"],
+          targets: ["climate_controller", "hydroponic_rack", "irrigation_system"] as const,
           value: 0.95,
         },
       ],
@@ -223,7 +245,7 @@ function createTrimmerUpgrades(): UpgradeDefinition[] {
 
   TRIMMER_THRESHOLDS.forEach((threshold, index) => {
     const stage = index + 1;
-    const id = `trimmer_auto_${stage}`;
+    const id = `trimmer_auto_${stage}` as UpgradeId;
     const name: Record<LocaleKey, string> = {
       de: `Trimm-Automation ${stage}`,
       en: `Trimmer Automation ${stage}`,
@@ -308,4 +330,6 @@ export const upgrades: UpgradeDefinition[] = [
   ...trimmerUpgrades,
 ].sort((a, b) => a.order - b.order);
 
-export const upgradeById = new Map(upgrades.map((upgrade) => [upgrade.id, upgrade] as const));
+export const upgradeById = new Map<UpgradeId, UpgradeDefinition>(
+  upgrades.map((upgrade) => [upgrade.id, upgrade]),
+);

--- a/cannaclicker/src/game/effects.ts
+++ b/cannaclicker/src/game/effects.ts
@@ -1,9 +1,10 @@
 import Decimal from "break_infinity.js";
 import { OFFLINE_CAP_MS } from "../app/balance";
 import type { GameState, SeedPassiveConfig } from "../app/state";
-import { researchById, type ResearchEffect, type StrainId } from "../data/research";
+import { researchById, type ResearchEffect, type StrainId, type ResearchId } from "../data/research";
+import type { ItemId } from "../data/items";
 
-export function applyEffects(state: GameState, owned: string[]): void {
+export function applyEffects(state: GameState, owned: ResearchId[]): void {
   let bpsMult = new Decimal(1);
   let bpcMult = new Decimal(1);
   let costMult = new Decimal(1);
@@ -16,8 +17,8 @@ export function applyEffects(state: GameState, owned: string[]): void {
   let seedClickBonus = 0;
   let passiveConfig: SeedPassiveConfig | null = null;
   let passiveScore = 0;
-  const buildingMultipliers = new Map<string, Decimal>();
-  const buildingCostMultipliers = new Map<string, Decimal>();
+  const buildingMultipliers = new Map<ItemId, Decimal>();
+  const buildingCostMultipliers = new Map<ItemId, Decimal>();
 
   for (const id of owned) {
     const node = researchById.get(id);
@@ -89,12 +90,12 @@ export function applyEffects(state: GameState, owned: string[]): void {
 
   const offlineCapMs = OFFLINE_CAP_MS + Math.max(0, offlineCapBonusHours) * 60 * 60 * 1000;
 
-  const researchBuildingMultipliers: Record<string, Decimal> = {};
+  const researchBuildingMultipliers: Partial<Record<ItemId, Decimal>> = {};
   for (const [key, value] of buildingMultipliers.entries()) {
     researchBuildingMultipliers[key] = value;
   }
 
-  const researchBuildingCostMultipliers: Record<string, Decimal> = {};
+  const researchBuildingCostMultipliers: Partial<Record<ItemId, Decimal>> = {};
   for (const [key, value] of buildingCostMultipliers.entries()) {
     researchBuildingCostMultipliers[key] = value;
   }
@@ -132,7 +133,7 @@ interface EffectContext {
   addOfflineHours: (value: number) => void;
   addHybridPerBuff: (value: number) => void;
   setStrain: (value: StrainId | null) => void;
-  multiplyBuilding: (target: string, value: number) => void;
+  multiplyBuilding: (target: ItemId, value: number) => void;
   addSeedClickBonus: (value: number) => void;
   setSeedPassive: (config: SeedPassiveConfig) => void;
 }


### PR DESCRIPTION
## Summary
- derive ItemId, UpgradeId, ResearchId, AchievementId, MilestoneId, and AbilityId unions from their data sources and expose typed lookup maps
- thread the new identifier types through game logic, saves, migrations, seed synergies, and UI refs so collections are strongly typed
- tag interactive UI elements with consistent data attributes while wiring shop, upgrade, research, prestige, and ability maps by domain key

## Testing
- `npm run lint`
- `npm run test` *(fails: no test files present)*

------
https://chatgpt.com/codex/tasks/task_e_68d534673ab0832db1d902884f166ef8