### PR TITLE
Handle missing event layer when creating random events

### DIFF
--- a/cannaclicker/src/app/ui/events/random.ts
+++ b/cannaclicker/src/app/ui/events/random.ts
@@ -26,10 +26,10 @@ export function createEventButton(
   state: GameState,
   lifetime: number,
   refs: UIRefs,
-): HTMLButtonElement {
-  const layer = refs.eventLayer ?? refs.eventRoot;
+): HTMLButtonElement | null {
+  const layer = refs.eventLayer ?? refs.eventRoot ?? null;
   if (!layer) {
-    throw new Error('Missing event layer');
+    return null;
   }
   const rect = layer.getBoundingClientRect();
   const path = computeEventPath(rect, lifetime);

--- a/cannaclicker/src/app/ui/events/scheduler/uiBindings.ts
+++ b/cannaclicker/src/app/ui/events/scheduler/uiBindings.ts
@@ -22,6 +22,10 @@ export const defaultSchedulerBindings: SchedulerBindings = {
     }
 
     const button = createEventButton(definition, state, lifetime, context.refs);
+    if (!button) {
+      return null;
+    }
+
     layer.appendChild(button);
     button.addEventListener("click", (event) => {
       event.preventDefault();


### PR DESCRIPTION
## Summary
- avoid throwing when the event layer is unavailable by returning null from createEventButton
- guard scheduler bindings against a null button so missing layers simply skip spawning

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5485f9aec832d9da478962daa7b58